### PR TITLE
Write out JSON files instead of serialized object.

### DIFF
--- a/controller/ev/chargepoint/config.yaml
+++ b/controller/ev/chargepoint/config.yaml
@@ -13,7 +13,7 @@ WSDL : https://webservices.chargepoint.com/cp_api_5.0.wsdl
 INTERVAL : 2
 SAVE_TO_FILE : True
 SAVE_ROOT : .
-FILENAME : load.data
+FILENAME : load.data.json
 STREAM : False
 STREAM_TO : None
 

--- a/controller/ev/chargepoint/cp.py
+++ b/controller/ev/chargepoint/cp.py
@@ -5,7 +5,9 @@ from config import config
 import constants
 from datetime import datetime
 from ev import ChargePoint, ChargeSessions, EVException, get_ENV_val
-import json
+# default JSON serializer of zeep.helpers.serialize_object doesnt handle
+# Decimal object but simplejson does.
+import simplejson as json
 import logging
 import os
 import time
@@ -104,9 +106,10 @@ def save_to_file(load):
     if DEBUG:
         print("Writing to file " + str(datafile))
 
-    datafile.write(
-        str(time.time()) + "  " +
-        str(zeep.helpers.serialize_object(load)) + "\n")
+    datafile.write(json.dumps({
+        'ts': time.time(),
+        'data': zeep.helpers.serialize_object(load),
+    }))
     datafile.flush()
     return
 

--- a/controller/ev/chargepoint/requirements.txt
+++ b/controller/ev/chargepoint/requirements.txt
@@ -1,5 +1,6 @@
 # Copyright 2020 program was created VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-zeep
 flask
+simplejson
+zeep


### PR DESCRIPTION
Example output
```
$ cat 2020/3/2/17/load.data.json | jq . |head -20
{
  "ts": 1583169037.9824715,
  "data": {
    "responseCode": "100",
    "responseText": "API input request executed successfully.",
    "sgID": XXXXXX,
    "numStations": 5,
    "groupName": "XXXXXX",
    "sgLoad": "40.348",
    "stationData": [
      {
        "stationID": "1:XXXXX",
        "stationName": "XXXXXXX",
        "Address": "XXXXXXX, Palo Alto, California,  94304, United States",
        "stationLoad": 12.163,
        "Port": [
          {
            "portNumber": "1",
            "userID": "XXXXXXX",

```