### PR TITLE
Use gmt time for logs and ISO8601 date formatting.

### DIFF
--- a/controller/ev/chargepoint/app.py
+++ b/controller/ev/chargepoint/app.py
@@ -1,11 +1,20 @@
 # Copyright Year(s) program was created VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
-
-from flask import Flask, request
-import cp
-from constants import DEBUG, SUCCESS
 import json
 import logging
+import time
+
+from flask import Flask, request
+
+import cp
+
+from constants import DEBUG, SUCCESS
+
+logging.Formatter.converter = time.gmtime
+formatter = logging.basicConfig(
+    format='%(asctime)s.%(msecs)03dZ %(levelname)s:%(name)s:%(message)s',
+    datefmt='%Y-%m-%dT%H:%M:%S',
+    level=logging.DEBUG)
 
 app = Flask(__name__)
 SUCCESS = "100"

--- a/controller/ev/chargepoint/cp.py
+++ b/controller/ev/chargepoint/cp.py
@@ -13,6 +13,13 @@ from zeep import Client
 import zeep.helpers
 from zeep.wsse.username import UsernameToken
 
+logging.Formatter.converter = time.gmtime
+formatter = logging.basicConfig(
+    format='%(asctime)s.%(msecs)03dZ %(levelname)s:%(name)s:%(message)s',
+    datefmt='%Y-%m-%dT%H:%M:%S',
+    level=logging.DEBUG)
+logging.getLogger('zeep').setLevel(logging.ERROR)
+
 # COMMON config
 DEBUG = "True" == config["COMMON"]["DEBUG"]
 


### PR DESCRIPTION
Logs now look like
```
$ python collect_data.py
2020-03-02T17:30:27.865Z DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): webservices.chargepoint.com:443
2020-03-02T17:30:28.218Z DEBUG:urllib3.connectionpool:https://webservices.chargepoint.com:443 "GET /cp_api_5.0.wsdl HTTP/1.1" 200 109143
2020-03-02T17:30:28.364Z INFO:root:Created SOAP ChargePoint client
<zeep.client.Client object at 0x7fb21fa7b5f8>
['238421']
id = 238421,
sgID = 238421,
stationID = None,
portID = None

2020-03-02T17:30:28.572Z DEBUG:urllib3.connectionpool:https://webservices.chargepoint.com:443 "POST /webservices/chargepoint/services/5.0 HTTP/1.1" 200 3479
1583170228.5761156  total_load @ sgID(238421) = 40.331

2020-03-02T17:30:28.576Z DEBUG:root:Writing load data to ./2020/3/2/17/load.data
```

```
$ python -m flask run --host=0.0.0.0
 * Environment: production
   WARNING: This is a development server. Do not use it in a production deployment.
   Use a production WSGI server instead.
 * Debug mode: off
2020-03-02T17:32:31.595Z INFO:werkzeug: * Running on http://0.0.0.0:5000/ (Press CTRL+C to quit)
```