### PR TITLE
ChargePoint API client library in Go.

### DIFF
--- a/controller/ev/chargepoint/go/client.go
+++ b/controller/ev/chargepoint/go/client.go
@@ -1,0 +1,108 @@
+package chargepoint
+
+import (
+	"context"
+	"io"
+	"net/http"
+
+	"github.com/CamusEnergy/kinney/controller/ev/chargepoint/go/schema"
+)
+
+// client provides an interface for communicating with a ChargePoint API server.
+type client struct {
+	url            string
+	securityHeader *securityHeader
+	httpClient     *http.Client
+	httpLogWriter  io.Writer
+}
+
+func NewClient(url, apiKey, apiPassword string, httpLogWriter io.Writer) *client {
+	return &client{
+		url:            url,
+		securityHeader: newSecurityHeader(apiKey, apiPassword),
+		httpClient:     http.DefaultClient,
+		httpLogWriter:  httpLogWriter,
+	}
+}
+
+// call simply wraps `soapCall`, filling in the common parameters from the
+// client's configuration.
+func (c *client) call(ctx context.Context, req, resp interface{}) error {
+	return soapCall(ctx, c.httpClient, c.url, c.securityHeader, req, nil, resp, c.httpLogWriter)
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// "Common API"
+////////////////////////////////////////////////////////////////////////////////
+
+// API Guide: "Use this call to retrieve ChargePoint NOS instances."
+func (c *client) GetCPNInstances(ctx context.Context, req *schema.GetCPNInstancesRequest) (*schema.GetCPNInstancesResponse, error) {
+	resp := &schema.GetCPNInstancesResponse{}
+	if err := c.call(ctx, req, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// "Station Management API"
+////////////////////////////////////////////////////////////////////////////////
+
+// API Guide: "Use this call to return a list of stations.  This will not return
+// stations that you don't have access rights to.  For example, it will not
+// return a public station unless you either own the station or have been
+// granted rights by the station's owner.  ...  Up to 500 stations will be
+// returned by this method."
+func (c *client) GetStations(ctx context.Context, req *schema.GetStationsRequest) (*schema.GetStationsResponse, error) {
+	resp := &schema.GetStationsResponse{}
+	if err := c.call(ctx, req, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// API Guide: "Use this call to retrieve custom station groups for any
+// organization.  It returns an array of groups for a given organization and
+// lists the stations included in each group."
+func (c *client) GetStationGroups(ctx context.Context, req *schema.GetStationGroupsRequest) (*schema.GetStationGroupsResponse, error) {
+	resp := &schema.GetStationGroupsResponse{}
+	if err := c.call(ctx, req, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// "Demand Management API"
+////////////////////////////////////////////////////////////////////////////////
+
+// API Guide: "Use this call to shed load for a single port on a station, both
+// ports on a multi-port station or a group of stations."
+func (c *client) ShedLoad(ctx context.Context, req *schema.ShedLoadRequest) (*schema.ShedLoadResponse, error) {
+	resp := &schema.ShedLoadResponse{}
+	if err := c.call(ctx, req, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// API Guide: "Use this call to clear the shed state from a single station or
+// group of stations."
+func (c *client) ClearShedState(ctx context.Context, req *schema.ClearShedStateRequest) (*schema.ClearShedStateResponse, error) {
+	resp := &schema.ClearShedStateResponse{}
+	if err := c.call(ctx, req, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// API Guide: "Use this call to retrieve the load and shed state for a single
+// station or custom station group.  This method also returns the load for each
+// port on a multi-port station."
+func (c *client) GetLoad(ctx context.Context, req *schema.GetLoadRequest) (*schema.GetLoadResponse, error) {
+	resp := &schema.GetLoadResponse{}
+	if err := c.call(ctx, req, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}

--- a/controller/ev/chargepoint/go/client.go
+++ b/controller/ev/chargepoint/go/client.go
@@ -1,3 +1,11 @@
+// Package chargepoint provides a native client library wrapping the
+// "ChargePoint Web Services API Version 5.0".
+//
+// Note that any comments quoted from the API Guide are indicated as such, and
+// will be quoted verbatim.
+//
+// TODO(james): Add more detail to the package comment, including examples of
+// how to use the library.
 package chargepoint
 
 import (
@@ -16,6 +24,13 @@ type client struct {
 	httpLogWriter  io.Writer
 }
 
+// NewCliant returns a new client instance that communicates with the given SOAP
+// Endpoint (`url`) with the given ChargePoint API credentials.  A record of
+// every HTTP exchange will be written to `httpLogWriter`, in JSONL format.
+//
+// Note that the ChargePoint Web Services API is a SOAP v1.1 endpoint protected
+// by a WS-Security "UsernameToken".  The username is the API license key, and
+// the password is the API password.
 func NewClient(url, apiKey, apiPassword string, httpLogWriter io.Writer) *client {
 	return &client{
 		url:            url,
@@ -32,10 +47,13 @@ func (c *client) call(ctx context.Context, req, resp interface{}) error {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// "Common API"
+// API Guide (§ 4): "Common API"
 ////////////////////////////////////////////////////////////////////////////////
 
-// API Guide: "Use this call to retrieve ChargePoint NOS instances."
+// API Guide (§ 4.1): "Use this call to retrieve ChargePoint NOS instances."
+//
+// TODO(james): Figure out what "NOS" means, as it is not documented in the API
+// Guide.
 func (c *client) GetCPNInstances(ctx context.Context, req *schema.GetCPNInstancesRequest) (*schema.GetCPNInstancesResponse, error) {
 	resp := &schema.GetCPNInstancesResponse{}
 	if err := c.call(ctx, req, resp); err != nil {
@@ -45,14 +63,15 @@ func (c *client) GetCPNInstances(ctx context.Context, req *schema.GetCPNInstance
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// "Station Management API"
+// API Guide (§ 8): "Station Management API"
 ////////////////////////////////////////////////////////////////////////////////
 
-// API Guide: "Use this call to return a list of stations.  This will not return
-// stations that you don't have access rights to.  For example, it will not
-// return a public station unless you either own the station or have been
-// granted rights by the station's owner.  ...  Up to 500 stations will be
-// returned by this method."
+// API Guide (§ 8.1): "Use this call to return a list of stations.  This will
+// not return stations that you don't have access rights to.  For example, it
+// will not return a public station unless you either own the station or have
+// been granted rights by the station's owner."
+//
+// API Guide (§ 8.1.1): "Up to 500 stations will be returned by this method."
 func (c *client) GetStations(ctx context.Context, req *schema.GetStationsRequest) (*schema.GetStationsResponse, error) {
 	resp := &schema.GetStationsResponse{}
 	if err := c.call(ctx, req, resp); err != nil {
@@ -61,7 +80,7 @@ func (c *client) GetStations(ctx context.Context, req *schema.GetStationsRequest
 	return resp, nil
 }
 
-// API Guide: "Use this call to retrieve custom station groups for any
+// API Guide (§ 8.3): "Use this call to retrieve custom station groups for any
 // organization.  It returns an array of groups for a given organization and
 // lists the stations included in each group."
 func (c *client) GetStationGroups(ctx context.Context, req *schema.GetStationGroupsRequest) (*schema.GetStationGroupsResponse, error) {
@@ -73,11 +92,11 @@ func (c *client) GetStationGroups(ctx context.Context, req *schema.GetStationGro
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// "Demand Management API"
+// API Guide (§ 6): "Demand Management API"
 ////////////////////////////////////////////////////////////////////////////////
 
-// API Guide: "Use this call to shed load for a single port on a station, both
-// ports on a multi-port station or a group of stations."
+// API Guide (§ 6.1): "Use this call to shed load for a single port on a
+// station, both ports on a multi-port station or a group of stations."
 func (c *client) ShedLoad(ctx context.Context, req *schema.ShedLoadRequest) (*schema.ShedLoadResponse, error) {
 	resp := &schema.ShedLoadResponse{}
 	if err := c.call(ctx, req, resp); err != nil {
@@ -86,8 +105,8 @@ func (c *client) ShedLoad(ctx context.Context, req *schema.ShedLoadRequest) (*sc
 	return resp, nil
 }
 
-// API Guide: "Use this call to clear the shed state from a single station or
-// group of stations."
+// API Guide (§ 6.2): "Use this call to clear the shed state from a single
+// station or group of stations."
 func (c *client) ClearShedState(ctx context.Context, req *schema.ClearShedStateRequest) (*schema.ClearShedStateResponse, error) {
 	resp := &schema.ClearShedStateResponse{}
 	if err := c.call(ctx, req, resp); err != nil {
@@ -96,9 +115,9 @@ func (c *client) ClearShedState(ctx context.Context, req *schema.ClearShedStateR
 	return resp, nil
 }
 
-// API Guide: "Use this call to retrieve the load and shed state for a single
-// station or custom station group.  This method also returns the load for each
-// port on a multi-port station."
+// API Guide (§ 6.3): "Use this call to retrieve the load and shed state for a
+// single station or custom station group.  This method also returns the load
+// for each port on a multi-port station."
 func (c *client) GetLoad(ctx context.Context, req *schema.GetLoadRequest) (*schema.GetLoadResponse, error) {
 	resp := &schema.GetLoadResponse{}
 	if err := c.call(ctx, req, resp); err != nil {

--- a/controller/ev/chargepoint/go/cmd/client/README.md
+++ b/controller/ev/chargepoint/go/cmd/client/README.md
@@ -1,0 +1,105 @@
+This tool allows issuing requests against the ChargePoint API from the command
+line:
+
+```bash
+> go build ./cmd/client
+
+> cat credentials.json
+{
+  "APIKey": "<SNIP>",
+  "APIPassword": "<SNIP>"
+}
+
+> ./client \
+    --credentials="credentials.json" \
+    --http_log="http_log.jsonl" \
+    --url="<API_URL>" \
+    --method="GetCPNInstances" \
+    --request="{}" \
+    | jq
+2020/05/11 22:31:20 Using request: &schema.GetCPNInstancesRequest{XMLName:xml.Name{Space:"", Local:""}}
+{
+  "XMLName": {
+    "Space": "ns1",
+    "Local": "getCPNInstancesResponse"
+  },
+  "ChargePointNetworks": [
+    {
+      "ChargePointNetworkID": "1",
+      "ChargePointNetworkName": "NA",
+      "ChargePointNetworkDescription": "ChargePoint Operations"
+    },
+    {
+      "ChargePointNetworkID": "2",
+      "ChargePointNetworkName": "EU",
+      "ChargePointNetworkDescription": "ChargePoint Europe"
+    },
+    {
+      "ChargePointNetworkID": "3",
+      "ChargePointNetworkName": "AU",
+      "ChargePointNetworkDescription": "ChargePoint Australia"
+    },
+    {
+      "ChargePointNetworkID": "4",
+      "ChargePointNetworkName": "CA",
+      "ChargePointNetworkDescription": "ChargePoint Canada"
+    }
+  ]
+}
+```
+
+The HTTP log is written in JSONL format (details are in `soap.go`), and so can
+also be inspected with `jq`:
+
+```bash
+> jq '(.RequestBody, .ResponseBody) |= @base64d' < http_log.jsonl
+{
+  "RequestTimestamp": "2020-05-11T22:31:20.736844-07:00",
+  "RequestMethod": "POST",
+  "RequestURL": "https://webservices.chargepoint.com/webservices/chargepoint/services/5.0",
+  "RequestHeaders": {
+    "Content-Type": [
+      "text/xml; charset=utf-8"
+    ]
+  },
+  "RequestBody": "<Envelope xmlns=\"http://schemas.xmlsoap.org/soap/envelope/\"><Header><Security xmlns=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\" xmlns:envelope=\"http://schemas.xmlsoap.org/soap/envelope/\" envelope:mustUnderstand=\"1\"><UsernameToken><Username>{{SNIP}}</Username><Password Type=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText\">{{SNIP}}</Password></UsernameToken></Security></Header><Body><getCPNInstances xmlns=\"urn:dictionary:com.chargepoint.webservices\"></getCPNInstances></Body></Envelope>",
+  "ResponseTimestamp": "2020-05-11T22:31:21.140106-07:00",
+  "ResponseStatusCode": 200,
+  "ResponseBody": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:ns1=\"urn:dictionary:com.chargepoint.webservices\"><SOAP-ENV:Body><ns1:getCPNInstancesResponse><CPN><cpnID>1</cpnID><cpnName>NA</cpnName><cpnDescription>ChargePoint Operations</cpnDescription></CPN><CPN><cpnID>2</cpnID><cpnName>EU</cpnName><cpnDescription>ChargePoint Europe</cpnDescription></CPN><CPN><cpnID>3</cpnID><cpnName>AU</cpnName><cpnDescription>ChargePoint Australia</cpnDescription></CPN><CPN><cpnID>4</cpnID><cpnName>CA</cpnName><cpnDescription>ChargePoint Canada</cpnDescription></CPN></ns1:getCPNInstancesResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>\n"
+}
+```
+
+`xmllint` can be used to pretty-print the XML:
+
+```console
+$ jq '(.RequestBody, .ResponseBody) |= @base64d | .ResponseBody' --raw-output \
+    < http_log.jsonl \
+    | xmllint --format -
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="urn:dictionary:com.chargepoint.webservices">
+  <SOAP-ENV:Body>
+    <ns1:getCPNInstancesResponse>
+      <CPN>
+        <cpnID>1</cpnID>
+        <cpnName>NA</cpnName>
+        <cpnDescription>ChargePoint Operations</cpnDescription>
+      </CPN>
+      <CPN>
+        <cpnID>2</cpnID>
+        <cpnName>EU</cpnName>
+        <cpnDescription>ChargePoint Europe</cpnDescription>
+      </CPN>
+      <CPN>
+        <cpnID>3</cpnID>
+        <cpnName>AU</cpnName>
+        <cpnDescription>ChargePoint Australia</cpnDescription>
+      </CPN>
+      <CPN>
+        <cpnID>4</cpnID>
+        <cpnName>CA</cpnName>
+        <cpnDescription>ChargePoint Canada</cpnDescription>
+      </CPN>
+    </ns1:getCPNInstancesResponse>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>
+```

--- a/controller/ev/chargepoint/go/cmd/client/main.go
+++ b/controller/ev/chargepoint/go/cmd/client/main.go
@@ -1,0 +1,121 @@
+// client is a reflection-based command-line interface to the ChargePoint API
+// client library.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"reflect"
+
+	chargepoint "github.com/CamusEnergy/kinney/controller/ev/chargepoint/go"
+)
+
+var (
+	credentialsFileName = flag.String("credentials", "", "JSON file containing the API credentials (see the `credentials` struct).  [required]")
+	httpLogFileName     = flag.String("http_log", "", "File to write the JSONL-formatted HTTP log to.  [required]")
+	url                 = flag.String("url", "", "URL of the ChargePoint API.  [required]")
+	method              = flag.String("method", "", "API method to call.  This must exactly match (case-sensitively) a method on the `client` type.  [required]")
+	request             = flag.String("request", "", "Request to send, specified as a JSON-marshalled instance of the request type.  [required]")
+)
+
+func main() {
+	// Run the main logic inside of a separate function to allow using
+	// `return <error>` to interrupt control flow (instead of `log.Fatal()`)
+	// to make sure that all cleanup handlers (`defer` statements) are run.
+	if err := mainInternal(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+type credentials struct {
+	APIKey      string
+	APIPassword string
+}
+
+func mainInternal() error {
+	flag.Parse()
+
+	switch {
+	case *credentialsFileName == "":
+		return errors.New("--credentials is required")
+	case *httpLogFileName == "":
+		return errors.New("--http_log is required")
+	case *url == "":
+		return errors.New("--url is required")
+	case *method == "":
+		return errors.New("--method is required")
+	case *request == "":
+		return errors.New("--request is required")
+	}
+
+	// Parse the file containing the credentials as a JSON-marshalled
+	// instance of the `credentials` struct type.
+	var creds credentials
+	if b, err := ioutil.ReadFile(*credentialsFileName); err != nil {
+		return fmt.Errorf("error reading credentials: %w", err)
+	} else if err := json.Unmarshal(b, &creds); err != nil {
+		return fmt.Errorf("error parsing credentials: %w", err)
+	} else if creds.APIKey == "" || creds.APIPassword == "" {
+		return errors.New("Credential file must specify both `APIKey` and `APIPassword`")
+	}
+
+	// Initialize the HTTP log file.
+	httpLog, err := os.Create(*httpLogFileName)
+	if err != nil {
+		return fmt.Errorf("error creating HTTP log file: %w", err)
+	}
+	defer httpLog.Close()
+
+	// Create the API client.
+	c := chargepoint.NewClient(*url, creds.APIKey, creds.APIPassword, httpLog)
+
+	// Get the API method to call.
+	methodVal := reflect.ValueOf(c).MethodByName(*method)
+	if !methodVal.IsValid() {
+		return fmt.Errorf("unsupported method: %s", *method)
+	} else if methodVal.Type().NumIn() != 2 {
+		return fmt.Errorf("client method has %q input parameters, want 2", methodVal.Type().NumIn())
+	} else if methodVal.Type().In(0) != reflect.TypeOf((*context.Context)(nil)).Elem() {
+		return fmt.Errorf("client method's first input parameter is %q, want `context.Context`", methodVal.Type().In(0))
+	} else if methodVal.Type().NumOut() != 2 {
+		return fmt.Errorf("client method has %q output parameters, want 2", methodVal.Type().NumOut())
+	}
+
+	// Get the type of the argument to the method on `client`.  Note that
+	// the first parameter (index "0") is a `context.Context`, so this
+	// parameter has index "1".
+	reqType := methodVal.Type().In(1)
+	if reqType.Kind() != reflect.Ptr {
+		return fmt.Errorf("request type has kind %q, expected 'Ptr'", reqType.Kind())
+	}
+
+	// Create a new instance of an object of that type.
+	req := reflect.New(reqType.Elem()).Interface()
+
+	// Unmarshal `--request` into `req`.
+	if err := json.Unmarshal([]byte(*request), req); err != nil {
+		return fmt.Errorf("error unmarshalling JSON request: %w", err)
+	}
+	log.Printf("Using request: %#v", req)
+
+	// Call the API method via the reflected client method.
+	out := methodVal.Call([]reflect.Value{reflect.ValueOf(context.Background()), reflect.ValueOf(req)})
+	respVal, errVal := out[0], out[1]
+
+	// Handle the output parameters.
+	if !errVal.IsNil() {
+		return fmt.Errorf("error calling API: %w", errVal.Interface().(error))
+	} else if b, err := json.Marshal(respVal.Interface()); err != nil {
+		return fmt.Errorf("error marshalling response as JSON: %w", err)
+	} else {
+		fmt.Println(string(b))
+	}
+
+	return nil
+}

--- a/controller/ev/chargepoint/go/schema/clear_shed_state.go
+++ b/controller/ev/chargepoint/go/schema/clear_shed_state.go
@@ -2,6 +2,8 @@ package schema
 
 import "encoding/xml"
 
+// API Guide (§ 6.2): "Use this call to clear the shed state from a single
+// station or group of stations."
 type ClearShedStateRequest struct {
 	XMLName xml.Name `xml:"urn:dictionary:com.chargepoint.webservices clearShedState"`
 
@@ -13,6 +15,12 @@ type ClearShedStateRequest struct {
 		Station *struct {
 			StationID string `xml:"stationID"`
 
+			// This part of the API is not documented in the API
+			// Guide, but it is part of the WSDL.
+			//
+			// TODO(james): Check if this is actually implemented in
+			// the API server.  If not, it should be removed from
+			// this schema representation.
 			Ports *struct {
 				PortNumbers []string `xml:"Port>portNumber"`
 			} `xml:"Ports,omitempty"`
@@ -25,7 +33,8 @@ type ClearShedStateResponse struct {
 
 	commonResponseParameters
 
-	// API Guide: "A success (1) or failure (0) response code only.
+	// API Guide (§ 6.2.3): "A success (1) or failure (0) response code
+	// only."
 	//
 	// This field has `type="xsd:int"` in the WSDL, but is semantically
 	// boolean, and can safely be parsed as such.

--- a/controller/ev/chargepoint/go/schema/clear_shed_state.go
+++ b/controller/ev/chargepoint/go/schema/clear_shed_state.go
@@ -1,0 +1,36 @@
+package schema
+
+import "encoding/xml"
+
+type ClearShedStateRequest struct {
+	XMLName xml.Name `xml:"urn:dictionary:com.chargepoint.webservices clearShedState"`
+
+	ShedQuery struct {
+		StationGroup *struct {
+			StationGroupID int32 `xml:"sgID"`
+		} `xml:"shedGroup,omitempty"`
+
+		Station *struct {
+			StationID string `xml:"stationID"`
+
+			Ports *struct {
+				PortNumbers []string `xml:"Port>portNumber"`
+			} `xml:"Ports,omitempty"`
+		} `xml:"shedStation,omitempty"`
+	} `xml:"shedQuery"`
+}
+
+type ClearShedStateResponse struct {
+	XMLName xml.Name `xml:"clearShedStateResponse"`
+
+	commonResponseParameters
+
+	// API Guide: "A success (1) or failure (0) response code only.
+	//
+	// This field has `type="xsd:int"` in the WSDL, but is semantically
+	// boolean, and can safely be parsed as such.
+	Success bool `xml:"Success,omitempty"`
+
+	StationGroupID int32  `xml:"sgID,omitempty"`
+	StationID      string `xml:"stationID,omitempty"`
+}

--- a/controller/ev/chargepoint/go/schema/common.go
+++ b/controller/ev/chargepoint/go/schema/common.go
@@ -1,0 +1,33 @@
+package schema
+
+// XML Schema 1.0 "time" built-in datatype.
+//
+// https://www.w3.org/TR/xmlschema-2/#time
+//
+// TODO(james): Add validation of the value.
+type xsdTime string
+
+// XML Schema 1.0 "dateTime" built-in datatype.
+//
+// https://www.w3.org/TR/xmlschema-2/#dateTime
+//
+// TODO(james): Add validation of the value.
+type xsdDateTime string
+
+// API Guide: "All responses of the ChargePoint Web Services API contain the
+// following parameters."
+type commonResponseParameters struct {
+	// API Guide: "Code indicating success or failure for the API call.
+	//
+	// Everything but "100" represents an error response.
+	ResponseCode string `xml:"responseCode"`
+
+	// API Guide: "If an error occurs, this field contains a description of
+	// the error.  If no error occurred, thsi field will be blank."
+	ResponseText string `xml:"responseText,omitempty"`
+}
+
+type Coordinate struct {
+	Latitude  string `xml:"Lat"`
+	Longitude string `xml:"Long"`
+}

--- a/controller/ev/chargepoint/go/schema/common.go
+++ b/controller/ev/chargepoint/go/schema/common.go
@@ -14,19 +14,22 @@ type xsdTime string
 // TODO(james): Add validation of the value.
 type xsdDateTime string
 
-// API Guide: "All responses of the ChargePoint Web Services API contain the
-// following parameters."
+// API Guide (§ 2.5): "All responses of the ChargePoint Web Services API contain
+// the following parameters."
 type commonResponseParameters struct {
-	// API Guide: "Code indicating success or failure for the API call.
+	// API Guide (§ 2.5): "Code indicating success or failure for the API
+	// call."
 	//
 	// Everything but "100" represents an error response.
 	ResponseCode string `xml:"responseCode"`
 
-	// API Guide: "If an error occurs, this field contains a description of
-	// the error.  If no error occurred, thsi field will be blank."
+	// API Guide (§ 2.5): "If an error occurs, this field contains a
+	// description of the error.  If no error occurred, this field will be
+	// blank."
 	ResponseText string `xml:"responseText,omitempty"`
 }
 
+// TODO(james): Figure out the CRS that the api uses for these coordinates.
 type Coordinate struct {
 	Latitude  string `xml:"Lat"`
 	Longitude string `xml:"Long"`

--- a/controller/ev/chargepoint/go/schema/get_cpn_instances.go
+++ b/controller/ev/chargepoint/go/schema/get_cpn_instances.go
@@ -2,6 +2,10 @@ package schema
 
 import "encoding/xml"
 
+// API Guide (§ 4.1): "Use this call to retrieve ChargePoint NOS instances."
+//
+// TODO(james): Figure out what "NOS" means, as it is not documented in the API
+// Guide.
 type GetCPNInstancesRequest struct {
 	XMLName xml.Name `xml:"urn:dictionary:com.chargepoint.webservices getCPNInstances"`
 }

--- a/controller/ev/chargepoint/go/schema/get_cpn_instances.go
+++ b/controller/ev/chargepoint/go/schema/get_cpn_instances.go
@@ -1,0 +1,17 @@
+package schema
+
+import "encoding/xml"
+
+type GetCPNInstancesRequest struct {
+	XMLName xml.Name `xml:"urn:dictionary:com.chargepoint.webservices getCPNInstances"`
+}
+
+type GetCPNInstancesResponse struct {
+	XMLName xml.Name `xml:"getCPNInstancesResponse"`
+
+	ChargePointNetworks []struct {
+		ChargePointNetworkID          string `xml:"cpnID,omitempty"`
+		ChargePointNetworkName        string `xml:"cpnName,omitempty"`
+		ChargePointNetworkDescription string `xml:"cpnDescription,omitempty"`
+	} `xml:"CPN,omitempty"`
+}

--- a/controller/ev/chargepoint/go/schema/get_load.go
+++ b/controller/ev/chargepoint/go/schema/get_load.go
@@ -5,6 +5,9 @@ import (
 	"math/big"
 )
 
+// API Guide (§ 6.3): "Use this call to retrieve the load and shed state for a
+// single station or custom station group.  This method also returns the load
+// for each port on a multi-port station."
 type GetLoadRequest struct {
 	XMLName xml.Name `xml:"urn:dictionary:com.chargepoint.webservices getLoad"`
 
@@ -31,18 +34,31 @@ type GetLoadResponse struct {
 		Ports []struct {
 			PortNumber string `xml:"portNumber,omitempty"`
 			UserID     string `xml:"userID,omitempty"`
-			// The empty string means that a contactless credit card
-			// was used to start the session.
+			// API Guide (§ 6.3.3): "Identifier of the credential
+			// used to start the session.  If it was a ChargePoint
+			// RFID card, it is the printed serial number on the
+			// card.  If it was the ChargePoint Mobile App, it will
+			// be the identifier displayed in the user’s mobile app.
+			// Contactless credit cards will be obviously be
+			// displayed as blank."
 			CredentialID *string `xml:"credentialID,omitempty"`
 
 			PortLoadKW big.Rat `xml:"portLoad,omitempty"`
 
-			// "1 = Shed, 0 = Not Shed"
+			// API Guide (§ 6.3.3): "1 = Shed, 0 = Not Shed"
 			ShedState uint8 `xml:"shedState"`
 
-			// Only one of the following two should be set.
-			// Maximum load allowed at the station.
+			// Only one of the following two fields should be set.
+
+			// API Guide (§ 6.3.3): "Maximum load allowed at the
+			// station (kW).  If percentShed was used in the last
+			// shedLoad call to this station, this parameter will be
+			// zero."
 			AllowedLoadKW *big.Rat `xml:"allowedLoad,omitempty"`
+			// API Guide (§ 6.3.3): "Percent of load currently being
+			// shed.  If allowedLoad was used in the last shedLoad
+			// call to this station, this parameter will be zero."
+			//
 			// Percent of load currently being shed (0 - 100).
 			PercentShed *uint8 `xml:"percentShed,omitempty"`
 		} `xml:"Port,omitempty"`

--- a/controller/ev/chargepoint/go/schema/get_load.go
+++ b/controller/ev/chargepoint/go/schema/get_load.go
@@ -1,0 +1,50 @@
+package schema
+
+import (
+	"encoding/xml"
+	"math/big"
+)
+
+type GetLoadRequest struct {
+	XMLName xml.Name `xml:"urn:dictionary:com.chargepoint.webservices getLoad"`
+
+	StationGroupID int32  `xml:"searchQuery>sgID,omitempty"`
+	StationID      string `xml:"searchQuery>stationID,omitempty"`
+}
+
+type GetLoadResponse struct {
+	XMLName xml.Name `xml:"getLoadResponse"`
+
+	commonResponseParameters
+
+	StationGroupID          int32  `xml:"sgID,omitempty"`
+	StationGroupNumStations int32  `xml:"numStations,omitempty"`
+	StationGroupName        string `xml:"groupName,omitempty"`
+	StationGroupLoadKW      string `xml:"sgLoad,omitempty"`
+
+	Stations []struct {
+		StationID      string  `xml:"stationID,omitempty"`
+		StationName    string  `xml:"stationName,omitempty"`
+		StationAddress string  `xml:"Address,omitempty"`
+		StationLoadKW  big.Rat `xml:"stationLoad,omitempty"`
+
+		Ports []struct {
+			PortNumber string `xml:"portNumber,omitempty"`
+			UserID     string `xml:"userID,omitempty"`
+			// The empty string means that a contactless credit card
+			// was used to start the session.
+			CredentialID *string `xml:"credentialID,omitempty"`
+
+			PortLoadKW big.Rat `xml:"portLoad,omitempty"`
+
+			// "1 = Shed, 0 = Not Shed"
+			ShedState uint8 `xml:"shedState"`
+
+			// Only one of the following two should be set.
+			// Maximum load allowed at the station.
+			AllowedLoadKW *big.Rat `xml:"allowedLoad,omitempty"`
+			// Percent of load currently being shed (0 - 100).
+			PercentShed *uint8 `xml:"percentShed,omitempty"`
+		} `xml:"Port,omitempty"`
+	} `xml:"stationData,omitempty"`
+}

--- a/controller/ev/chargepoint/go/schema/get_station_groups.go
+++ b/controller/ev/chargepoint/go/schema/get_station_groups.go
@@ -1,0 +1,28 @@
+package schema
+
+import "encoding/xml"
+
+type GetStationGroupsRequest struct {
+	XMLName xml.Name `xml:"urn:dictionary:com.chargepoint.webservices getStationGroups"`
+
+	OrganizationID string `xml:"orgID"`
+}
+
+type GetStationGroupsResponse struct {
+	XMLName xml.Name `xml:"getStationGroupsResponse"`
+
+	commonResponseParameters
+
+	StationGroups []struct {
+		OrganizationID   string `xml:"orgID,omitempty"`
+		OrganizationName string `xml:"organizationName,omitempty"`
+
+		StationGroupID   int32  `xml:"sgID,omitempty"`
+		StationGroupName string `xml:"sgName,omitempty"`
+
+		Stations []struct {
+			StationID  string      `xml:"stationID,omitempty"`
+			Coordinate *Coordinate `xml:"Geo,omitempty"`
+		} `xml:"stationData,omitempty"`
+	} `xml:"groupData,omitempty"`
+}

--- a/controller/ev/chargepoint/go/schema/get_station_groups.go
+++ b/controller/ev/chargepoint/go/schema/get_station_groups.go
@@ -2,6 +2,9 @@ package schema
 
 import "encoding/xml"
 
+// API Guide (§ 8.3): "Use this call to retrieve custom station groups for any
+// organization.  It returns an array of groups for a given organization and
+// lists the stations included in each group."
 type GetStationGroupsRequest struct {
 	XMLName xml.Name `xml:"urn:dictionary:com.chargepoint.webservices getStationGroups"`
 

--- a/controller/ev/chargepoint/go/schema/get_stations.go
+++ b/controller/ev/chargepoint/go/schema/get_stations.go
@@ -5,27 +5,35 @@ import (
 	"math/big"
 )
 
+// API Guide (§ 8.1): "Use this call to return a list of stations.  This will
+// not return stations that you don't have access rights to.  For example, it
+// will not return a public station unless you either own the station or have
+// been granted rights by the station's owner."
+//
+// API Guide (§ 8.1.1): "Up to 500 stations will be returned by this method."
 type GetStationsRequest struct {
 	XMLName xml.Name `xml:"urn:dictionary:com.chargepoint.webservices getStations"`
 
 	SearchQuery struct {
-		// API Guide: "A unique station identifier used in ChargePoint.  This
-		// identifier never changes, even when the station's head assembly is
-		// swapped.  Format : CPNID:StationIdentifier."
+		// API Guide (§ 8.1.2): "A unique station identifier used in
+		// ChargePoint.  This identifier never changes, even when the
+		// station's head assembly is swapped.  Format:
+		// CPNID:StationIdentifier."
 		StationID           string `xml:"stationID,omitempty"`
 		StationManufacturer string `xml:"stationManufacturer,omitempty"`
 		StationModel        string `xml:"stationModel,omitempty"`
-		// API Guide: "Name of the station (wild card characters are allowed).
-		// It should be searched for by both company name (the name of the
-		// organization that owns the charging station) and station name.
-		// Company name is displayed on Line 1 of the charging station (if
-		// applicable) and the station name is displayed on Line 2 of the
-		// charging station (if applicable)."
+		// API Guide (§ 8.1.2): "Name of the station (wild card
+		// characters are allowed).  It should be searched for by both
+		// company name (the name of the organization that owns the
+		// charging station) and station name.  Company name is
+		// displayed on Line 1 of the charging station (if applicable)
+		// and the station name is displayed on Line 2 of the charging
+		// station (if applicable)."
 		StationName string `xml:"stationName,omitempty"`
 
-		// API Guide: "Address around which you want to see stations.  This can
-		// be street address or complete address (stree address, city, state,
-		// zip code, country)."
+		// API Guide (§ 8.1.2): "Address around which you want to see
+		// stations.  This can be street address or complete address
+		// (street address, city, state, zip code, country)."
 		Address    string `xml:"Address,omitempty"`
 		City       string `xml:"City,omitempty"`
 		State      string `xml:"State,omitempty"`
@@ -33,71 +41,99 @@ type GetStationsRequest struct {
 		PostalCode string `xml:"postalCode,omitempty"`
 
 		Coordinate *Coordinate `xml:"Geo,omitempty"`
-		// API Guide: "Distance from the station's specified lat/long (Geo) from
-		// which you want to retrieve station information.  Default is 5"
+		// API Guide (§ 8.1.2): "Distance from the station's specified
+		// lat/long (Geo) from which you want to retrieve station
+		// information.  Default is 5"
 		Proximity *big.Rat `xml:"Proximity,omitempty"`
-		// API Guide: "Default value for proximity unit is M.  Can have values: M
-		// (miles), N (Nautical miles), K (Kilometer), F (Feet), I (Inches)."
+		// API Guide (§ 8.1.2): "Default value for proximity unit is M.
+		// Can have values: M (miles), N (Nautical miles), K
+		// (Kilometer), F (Feet), I (Inches)."
 		ProximityUnit string `xml:"proximityUnit,omitempty"`
 
-		// WSDL: "Possible values 1 is Level 1, 2 is Level 2, 3 is Level 1 2 ,4
-		// is DC charger, 5 Level 1, Level2, DC charger"
+		// WSDL: "Possible values 1 is Level 1, 2 is Level 2, 3 is Level
+		// 1 2 ,4 is DC charger, 5 Level 1, Level2, DC charger"
 		//
-		// API Guide: "Station level type where 1 is 'Level 1', 2 is 'Level 2',
-		// 3 is 'Level 3', and 4 is 'DC Fast'.  If a station has more than one
-		// level (for example, the station provides both level 1 and level 2
-		// charging), the response will includ both level (1,2).  Note: This
-		// parameter is for 'US Stations' and 'AU Stations' only (and is used
-		// instead of 'Mode').
+		// API Guide (§ 8.1.2): "Station level type where 1 is 'Level
+		// 1', 2 is 'Level 2', 3 is 'Level 3', and 4 is 'DC Fast'.  If a
+		// station has more than one level (for example, the station
+		// provides both level 1 and level 2 charging), the response
+		// will includ both level (1,2).  Note: This parameter is for
+		// 'US Stations' and 'AU Stations' only (and is used instead of
+		// 'Mode')."
 		Level string `xml:"Level,omitempty"`
-		// API Guide: "Station mode type where 1 is 'Mode 1', 3 is 'Mode 3', and
-		// 4 is 'DC Fast'.  If the station has more than one mode (for example,
-		// the station provides both mode 1 with a domestic socket and mode 3
-		// charging with an IEC 62196 Type 2 socket), the response will include
-		// both modes (1,3).  Note: This parameter is for "EU Stations" only
-		// (and is used instead of "Level").
+		// API Guide (§ 8.1.2): "Station mode type where 1 is 'Mode 1',
+		// 3 is 'Mode 3', and 4 is 'DC Fast'.  If the station has more
+		// than one mode (for example, the station provides both mode 1
+		// with a domestic socket and mode 3 charging with an IEC 62196
+		// Type 2 socket), the response will include both modes (1,3).
+		// Note: This parameter is for "EU Stations" only (and is used
+		// instead of "Level").
 		Mode string `xml:"Mode,omitempty"`
 
 		PricingSession *PricingSession `xml:"Pricing,omitempty"`
 
-		// API Guide: "Whether or not the station can be reserved: '1' - the
-		// station can be reserved.  '0' - the station cannot be reserved."
+		// API Guide (§ 8.1.2): "Whether or not the station can be
+		// reserved: '1' - the station can be reserved.  '0' - the
+		// station cannot be reserved."
 		Reservable uint8 `xml:"Reservable,omitempty"`
 
-		// API Guide: "Connector type.  For example: NEMA 5-20R, J1772, ALFENL3,
-		// Shuko."
+		// API Guide (§ 8.1.2): "Connector type.  For example: NEMA
+		// 5-20R, J1772, ALFENL3, Shuko."
 		Connector string `xml:"Connector,omitempty"`
 
-		// API Guide: "Nominal voltage (V)."
+		// API Guide (§ 8.1.2): "Nominal voltage (V)."
 		Voltage string `xml:"Voltage,omitempty"`
-		// API Guide: "Current supported (A)."
+		// API Guide (§ 8.1.2): "Current supported (A)."
 		Current string `xml:"Current,omitempty"`
-		// API Guide: "Power supported (kW)."
+		// API Guide (§ 8.1.2): "Power supported (kW)."
 		PowerKW string `xml:"Power,omitempty"`
 
-		// API Guide: "Array of serial numbers of stations identified as a
-		// 'demo'.  Used only for client applications that need to access
-		// stations identified as 'demo'.
+		// API Guide (§ 8.1.2): "Array of serial numbers of stations
+		// identified as a 'demo'.  Used only for client applications
+		// that need to access stations identified as 'demo'.
 		DemoStations *struct {
 			SerialNumbers []string `xml:"serialNumber"`
 		} `xml:"demoSerialNumber,omitempty"`
 
-		// API Guide: "The org identifier CPNID:CompanyID"
+		// API Guide (§ 8.1.2): "The org identifier CPNID:CompanyID"
 		OrganizationID   string `xml:"orgID,omitempty"`
 		OrganizationName string `xml:"organizationName,omitempty"`
 		StationGroupID   string `xml:"sgID,omitempty"`
 		StationGroupName string `xml:"sgName,omitempty"`
 
-		// API Guide: "Start index for the stations that match the query."
+		// API Guide (§ 8.1.2): "Start index for the stations that match
+		// the query."
 		StartRecord int32 `xml:"startRecord,omitempty"`
-		// API Guide: "Number of stations to return in the response.  Maximum is
-		// 500, and if left blank, the method will return up to 500 stations."
+		// API Guide (§ 8.1.2): "Number of stations to return in the
+		// response.  Maximum is 500, and if left blank, the method will
+		// return up to 500 stations."
 		NumRecords int32 `xml:"numStations,omitempty"`
 
 		// Undocumented in the API Guide, but exist in the WSDL.
 		SerialNumber          string      `xml:"serialNumber,omitempty"`
 		StationActivationDate xsdDateTime `xml:"stationActivationDate,omitempty"`
 	} `xml:"searchQuery"`
+}
+
+type PricingSession struct {
+	StartTime xsdTime `xml:"startTime"`
+
+	// WSDL: "Expected duration of charging session in minutes."
+	//
+	// API Guide (§ 8.1.2): "Estimated duration of session in hours"
+	ExpectedDurationMinutes int32 `xml:"Duration"`
+	// API Guide (§ 8.1.2): "Estimated energy needed for a charging session in kWh."
+	ExpectedDurationKWh float64 `xml:"energyRequired"`
+
+	// This field is part of the XSD type used by "getStations", but is not
+	// documented for that request.  It is only documented in § 5.1
+	// ("getPublicStations"), § 5.2 ("getPublicStationStatus"), and § 8.2
+	// ("getStatusStatus").  It does however, appear in the sample
+	// "getStations" request in § 8.1.4.
+	//
+	// API Guide (§ 5.1.2): "If a session is active, present amount of power
+	// in kW being delivered to the vehicle."
+	PowerDrawKW float64 `xml:"vehiclePower"`
 }
 
 type GetStationsResponse struct {
@@ -117,8 +153,8 @@ type GetStationsResponse struct {
 		OrganizationID   string `xml:"orgID"`
 		OrganizationName string `xml:"organizationName"`
 
-		// API Guide: "Complete address (street address, city, state,
-		// zip code, country)."
+		// API Guide (§ 8.1.3): "Complete address (street address, city,
+		// state, zip code, country)."
 		Address    string `xml:"Address,omitempty"`
 		City       string `xml:"City,omitempty"`
 		State      string `xml:"State,omitempty"`
@@ -128,9 +164,9 @@ type GetStationsResponse struct {
 		NumPorts int32  `xml:"numPorts,omitempty"`
 		Ports    []Port `xml:"Port,omitempty"`
 
-		// API Guide: "The ISO 4217 code for the currency used on the
-		// station.  For eample, US Dollar = USD, Canadian Dollar = CAD,
-		// Euro = EUR."
+		// API Guide (§ 8.1.3): "The ISO 4217 code for the currency used
+		// on the station.  For eample, US Dollar = USD, Canadian Dollar
+		// = CAD, Euro = EUR."
 		CurrencyCode string `xml:"currencyCode,omitempty"`
 
 		// `maxOccurs` for this element in the WSDL is 2.
@@ -142,17 +178,17 @@ type GetStationsResponse struct {
 		StationActivationDate xsdDateTime `xml:"stationActivationDate,omitempty"`
 		DriverName            string      `xml:"driverName,omitempty"`
 		DriverAddress         string      `xml:"driverAddress,omitempty"`
-		DirverEmail           string      `xml:"driverEmail,omitempty"`
+		DriverEmail           string      `xml:"driverEmail,omitempty"`
 		DriverPhoneNumber     string      `xml:"driverPhoneNumber,omitempty"`
 		LastModifiedDate      xsdDateTime `xml:"lastModifiedDate,omitempty"`
 		ModTimeStamp          xsdDateTime `xml:"modTimeStamp,omitempty"`
 		TimezoneOffset        string      `xml:"timezoneOffset,omitempty"`
 	} `xml:"stationData,omitempty"`
 
-	// API Guide: "Indicates that the number of stations that match this
-	// query is greater than the maximum number of stations that can be
-	// returned in one call (currently 500), and therefore the list was
-	// truncated."
+	// API Guide (§ 8.1.3): "Indicates that the number of stations that
+	// match this query is greater than the maximum number of stations that
+	// can be returned in one call (currently 500), and therefore the list
+	// was truncated."
 	//
 	// This field has `type="xsd:int"` in the WSDL, but is semantically
 	// boolean (the value should either be "0" or "1"), and can safely be
@@ -161,45 +197,51 @@ type GetStationsResponse struct {
 }
 
 type PricingSpecification struct {
-	// API Guide: "Pricing Type (Session, Hourly, or kWh)"
+	// API Guide (§ 8.1.3): "Pricing Type (Session, Hourly, or kWh)"
 	Type string `xml:"Type,omitempty"`
 
-	// API Guide: "The start time of a pricing session."
+	// API Guide (§ 8.1.3): "The start time of a pricing session."
 	StartTime xsdTime `xml:"startTime,omitempty"`
-	// API Guide: "The end time of a pricing session."
+	// API Guide (§ 8.1.3): "The end time of a pricing session."
 	EndTime xsdTime `xml:"endTime,omitempty"`
 
-	// API Guide: "Maximum time allowed for a session."
+	// API Guide (§ 8.1.3): "Maximum time allowed for a session."
 	MaxSessionTime string `xml:"sessionTime,omitempty"`
 
-	// API Guide: "The minimum price charged for a session."
+	// API Guide (§ 8.1.3): "The minimum price charged for a session."
 	MinPrice float64 `xml:"minPrice,omitempty"`
-	// API Guide: "The maximum price charged for a session."
+	// API Guide (§ 8.1.3): "The maximum price charged for a session."
 	MaxPrice float64 `xml:"maxPrice,omitempty"`
 
-	initialUnitPriceDuration int32 `xml:"initialUnitPriceDuration,omitempty"`
-
-	// API Guide: "The hourly price if this mode of pricing is enabled"
+	// API Guide (§ 8.1.3): "The hourly price if this mode of pricing is
+	// enabled"
 	UnitPricePerHour float64 `xml:"unitPricePerHour,omitempty"`
-	// API Guide: "The session price if this mode of pricing is enabled"
+	// API Guide (§ 8.1.3): "The session price if this mode of pricing is
+	// enabled"
 	UnitPricePerSession float64 `xml:"unitPricePerSession,omitempty"`
-	// API Guide: "The kWh price if this mode of pricing is enabled"
+	// API Guide (§ 8.1.3): "The kWh price if this mode of pricing is
+	// enabled"
 	UnitPricePerKWh float64 `xml:"unitPricePerKWh,omitempty"`
 
 	// This field is documented in the API Guide, but does not exist in the
 	// WSDL.
 	//
-	// API Guide: "The hourly price for the first portion of the pricing
-	// specification if pricing varies by length of time"
+	// API Guide (§ 8.1.3): "The hourly price for the first portion of the
+	// pricing specification if pricing varies by length of time"
 	UnitPriceForFirst float64 `xml:"unitPriceForFirst,omitempty"`
 
-	// API Guide: "The hourly price for the second portion of the pricing
-	// specification if pricing varies by length of time"
+	// This field is in the WSDL, but not in the API Guide.  It is most
+	// likely the duration of that "first unit" (corresponding to
+	// `UnitPriceForFirst`).
+	initialUnitPriceDuration int32 `xml:"initialUnitPriceDuration,omitempty"`
+
+	// API Guide (§ 8.1.3): "The hourly price for the second portion of the
+	// pricing specification if pricing varies by length of time"
 	UnitPricePerHourThereafter float64 `xml:"unitPricePerHourThereafter,omitempty"`
 }
 
 type Port struct {
-	// API Guide: "Identifier of the port.  This ID is 1 based."
+	// API Guide (§ 8.1.3): "Identifier of the port.  This ID is 1 based."
 	PortNumber string `xml:"portNumber,omitempty"`
 
 	StationName string      `xml:"stationName,omitempty"`
@@ -217,19 +259,4 @@ type Port struct {
 	Status        string      `xml:"Status,omitempty"`
 	Timestamp     xsdDateTime `xml:"timeStamp,omitempty"`
 	EstimatedCost float64     `xml:"estimatedCost,omitempty"`
-}
-
-type PricingSession struct {
-	StartTime xsdTime `xml:"startTime"`
-
-	// WSDL: "Expected duration of charging session in minutes."
-	//
-	// API Guide: "Estimated duration of session in hours"
-	ExpectedDurationMinutes int32 `xml:"Duration"`
-	// API Guide: "Estimated energy needed for a charging session in kWh."
-	ExpectedDurationKWh float64 `xml:"energyRequired"`
-
-	// API Guide: "If a session is active, present amount of power in kW
-	// being delivered to the vehicle."
-	PowerDrawKW float64 `xml:"vehiclePower"`
 }

--- a/controller/ev/chargepoint/go/schema/get_stations.go
+++ b/controller/ev/chargepoint/go/schema/get_stations.go
@@ -1,0 +1,235 @@
+package schema
+
+import (
+	"encoding/xml"
+	"math/big"
+)
+
+type GetStationsRequest struct {
+	XMLName xml.Name `xml:"urn:dictionary:com.chargepoint.webservices getStations"`
+
+	SearchQuery struct {
+		// API Guide: "A unique station identifier used in ChargePoint.  This
+		// identifier never changes, even when the station's head assembly is
+		// swapped.  Format : CPNID:StationIdentifier."
+		StationID           string `xml:"stationID,omitempty"`
+		StationManufacturer string `xml:"stationManufacturer,omitempty"`
+		StationModel        string `xml:"stationModel,omitempty"`
+		// API Guide: "Name of the station (wild card characters are allowed).
+		// It should be searched for by both company name (the name of the
+		// organization that owns the charging station) and station name.
+		// Company name is displayed on Line 1 of the charging station (if
+		// applicable) and the station name is displayed on Line 2 of the
+		// charging station (if applicable)."
+		StationName string `xml:"stationName,omitempty"`
+
+		// API Guide: "Address around which you want to see stations.  This can
+		// be street address or complete address (stree address, city, state,
+		// zip code, country)."
+		Address    string `xml:"Address,omitempty"`
+		City       string `xml:"City,omitempty"`
+		State      string `xml:"State,omitempty"`
+		Country    string `xml:"Country,omitempty"`
+		PostalCode string `xml:"postalCode,omitempty"`
+
+		Coordinate *Coordinate `xml:"Geo,omitempty"`
+		// API Guide: "Distance from the station's specified lat/long (Geo) from
+		// which you want to retrieve station information.  Default is 5"
+		Proximity *big.Rat `xml:"Proximity,omitempty"`
+		// API Guide: "Default value for proximity unit is M.  Can have values: M
+		// (miles), N (Nautical miles), K (Kilometer), F (Feet), I (Inches)."
+		ProximityUnit string `xml:"proximityUnit,omitempty"`
+
+		// WSDL: "Possible values 1 is Level 1, 2 is Level 2, 3 is Level 1 2 ,4
+		// is DC charger, 5 Level 1, Level2, DC charger"
+		//
+		// API Guide: "Station level type where 1 is 'Level 1', 2 is 'Level 2',
+		// 3 is 'Level 3', and 4 is 'DC Fast'.  If a station has more than one
+		// level (for example, the station provides both level 1 and level 2
+		// charging), the response will includ both level (1,2).  Note: This
+		// parameter is for 'US Stations' and 'AU Stations' only (and is used
+		// instead of 'Mode').
+		Level string `xml:"Level,omitempty"`
+		// API Guide: "Station mode type where 1 is 'Mode 1', 3 is 'Mode 3', and
+		// 4 is 'DC Fast'.  If the station has more than one mode (for example,
+		// the station provides both mode 1 with a domestic socket and mode 3
+		// charging with an IEC 62196 Type 2 socket), the response will include
+		// both modes (1,3).  Note: This parameter is for "EU Stations" only
+		// (and is used instead of "Level").
+		Mode string `xml:"Mode,omitempty"`
+
+		PricingSession *PricingSession `xml:"Pricing,omitempty"`
+
+		// API Guide: "Whether or not the station can be reserved: '1' - the
+		// station can be reserved.  '0' - the station cannot be reserved."
+		Reservable uint8 `xml:"Reservable,omitempty"`
+
+		// API Guide: "Connector type.  For example: NEMA 5-20R, J1772, ALFENL3,
+		// Shuko."
+		Connector string `xml:"Connector,omitempty"`
+
+		// API Guide: "Nominal voltage (V)."
+		Voltage string `xml:"Voltage,omitempty"`
+		// API Guide: "Current supported (A)."
+		Current string `xml:"Current,omitempty"`
+		// API Guide: "Power supported (kW)."
+		PowerKW string `xml:"Power,omitempty"`
+
+		// API Guide: "Array of serial numbers of stations identified as a
+		// 'demo'.  Used only for client applications that need to access
+		// stations identified as 'demo'.
+		DemoStations *struct {
+			SerialNumbers []string `xml:"serialNumber"`
+		} `xml:"demoSerialNumber,omitempty"`
+
+		// API Guide: "The org identifier CPNID:CompanyID"
+		OrganizationID   string `xml:"orgID,omitempty"`
+		OrganizationName string `xml:"organizationName,omitempty"`
+		StationGroupID   string `xml:"sgID,omitempty"`
+		StationGroupName string `xml:"sgName,omitempty"`
+
+		// API Guide: "Start index for the stations that match the query."
+		StartRecord int32 `xml:"startRecord,omitempty"`
+		// API Guide: "Number of stations to return in the response.  Maximum is
+		// 500, and if left blank, the method will return up to 500 stations."
+		NumRecords int32 `xml:"numStations,omitempty"`
+
+		// Undocumented in the API Guide, but exist in the WSDL.
+		SerialNumber          string      `xml:"serialNumber,omitempty"`
+		StationActivationDate xsdDateTime `xml:"stationActivationDate,omitempty"`
+	} `xml:"searchQuery"`
+}
+
+type GetStationsResponse struct {
+	XMLName xml.Name `xml:"getStationsResponse"`
+
+	commonResponseParameters
+
+	Stations []struct {
+		StationID           string `xml:"stationID,omitempty"`
+		StationManufacturer string `xml:"stationManufacturer,omitempty"`
+		StationModel        string `xml:"stationModel,omitempty"`
+		StationMACAddress   string `xml:"stationMacAddr,omitempty"`
+		StationSerialNumber string `xml:"stationSerialNum,omitempty"`
+
+		StationGroupID   string `xml:"sgID,omitempty"`
+		StationGroupName string `xml:"sgName,omitempty"`
+		OrganizationID   string `xml:"orgID"`
+		OrganizationName string `xml:"organizationName"`
+
+		// API Guide: "Complete address (street address, city, state,
+		// zip code, country)."
+		Address    string `xml:"Address,omitempty"`
+		City       string `xml:"City,omitempty"`
+		State      string `xml:"State,omitempty"`
+		Country    string `xml:"Country,omitempty"`
+		PostalCode string `xml:"postalCode,omitempty"`
+
+		NumPorts int32  `xml:"numPorts,omitempty"`
+		Ports    []Port `xml:"Port,omitempty"`
+
+		// API Guide: "The ISO 4217 code for the currency used on the
+		// station.  For eample, US Dollar = USD, Canadian Dollar = CAD,
+		// Euro = EUR."
+		CurrencyCode string `xml:"currencyCode,omitempty"`
+
+		// `maxOccurs` for this element in the WSDL is 2.
+		PricingSpecification []PricingSpecification `xml:"Pricing,omitempty"`
+
+		DriverSupportPhoneNumber string `xml:"mainPhone,omitempty"`
+
+		// Undocumented in the API Guide, but exist in the WSDL.
+		StationActivationDate xsdDateTime `xml:"stationActivationDate,omitempty"`
+		DriverName            string      `xml:"driverName,omitempty"`
+		DriverAddress         string      `xml:"driverAddress,omitempty"`
+		DirverEmail           string      `xml:"driverEmail,omitempty"`
+		DriverPhoneNumber     string      `xml:"driverPhoneNumber,omitempty"`
+		LastModifiedDate      xsdDateTime `xml:"lastModifiedDate,omitempty"`
+		ModTimeStamp          xsdDateTime `xml:"modTimeStamp,omitempty"`
+		TimezoneOffset        string      `xml:"timezoneOffset,omitempty"`
+	} `xml:"stationData,omitempty"`
+
+	// API Guide: "Indicates that the number of stations that match this
+	// query is greater than the maximum number of stations that can be
+	// returned in one call (currently 500), and therefore the list was
+	// truncated."
+	//
+	// This field has `type="xsd:int"` in the WSDL, but is semantically
+	// boolean (the value should either be "0" or "1"), and can safely be
+	// parsed as such.
+	Truncated bool `xml:"moreFlag,omitempty"`
+}
+
+type PricingSpecification struct {
+	// API Guide: "Pricing Type (Session, Hourly, or kWh)"
+	Type string `xml:"Type,omitempty"`
+
+	// API Guide: "The start time of a pricing session."
+	StartTime xsdTime `xml:"startTime,omitempty"`
+	// API Guide: "The end time of a pricing session."
+	EndTime xsdTime `xml:"endTime,omitempty"`
+
+	// API Guide: "Maximum time allowed for a session."
+	MaxSessionTime string `xml:"sessionTime,omitempty"`
+
+	// API Guide: "The minimum price charged for a session."
+	MinPrice float64 `xml:"minPrice,omitempty"`
+	// API Guide: "The maximum price charged for a session."
+	MaxPrice float64 `xml:"maxPrice,omitempty"`
+
+	initialUnitPriceDuration int32 `xml:"initialUnitPriceDuration,omitempty"`
+
+	// API Guide: "The hourly price if this mode of pricing is enabled"
+	UnitPricePerHour float64 `xml:"unitPricePerHour,omitempty"`
+	// API Guide: "The session price if this mode of pricing is enabled"
+	UnitPricePerSession float64 `xml:"unitPricePerSession,omitempty"`
+	// API Guide: "The kWh price if this mode of pricing is enabled"
+	UnitPricePerKWh float64 `xml:"unitPricePerKWh,omitempty"`
+
+	// This field is documented in the API Guide, but does not exist in the
+	// WSDL.
+	//
+	// API Guide: "The hourly price for the first portion of the pricing
+	// specification if pricing varies by length of time"
+	UnitPriceForFirst float64 `xml:"unitPriceForFirst,omitempty"`
+
+	// API Guide: "The hourly price for the second portion of the pricing
+	// specification if pricing varies by length of time"
+	UnitPricePerHourThereafter float64 `xml:"unitPricePerHourThereafter,omitempty"`
+}
+
+type Port struct {
+	// API Guide: "Identifier of the port.  This ID is 1 based."
+	PortNumber string `xml:"portNumber,omitempty"`
+
+	StationName string      `xml:"stationName,omitempty"`
+	Coordinate  *Coordinate `xml:"Geo,omitempty"`
+	Reservable  uint8       `xml:"Reservable,omitempty"`
+	Level       string      `xml:"Level,omitempty"`
+	Mode        string      `xml:"Mode,omitempty"`
+	Connector   string      `xml:"Connector,omitempty"`
+	Voltage     string      `xml:"Voltage,omitempty"`
+	Current     string      `xml:"Current,omitempty"`
+	PowerKW     string      `xml:"Power,omitempty"`
+
+	// Undocumented in the API Guide, but exist in the WSDL
+	Description   string      `xml:"Desription,omitempty"`
+	Status        string      `xml:"Status,omitempty"`
+	Timestamp     xsdDateTime `xml:"timeStamp,omitempty"`
+	EstimatedCost float64     `xml:"estimatedCost,omitempty"`
+}
+
+type PricingSession struct {
+	StartTime xsdTime `xml:"startTime"`
+
+	// WSDL: "Expected duration of charging session in minutes."
+	//
+	// API Guide: "Estimated duration of session in hours"
+	ExpectedDurationMinutes int32 `xml:"Duration"`
+	// API Guide: "Estimated energy needed for a charging session in kWh."
+	ExpectedDurationKWh float64 `xml:"energyRequired"`
+
+	// API Guide: "If a session is active, present amount of power in kW
+	// being delivered to the vehicle."
+	PowerDrawKW float64 `xml:"vehiclePower"`
+}

--- a/controller/ev/chargepoint/go/schema/schema.go
+++ b/controller/ev/chargepoint/go/schema/schema.go
@@ -1,0 +1,32 @@
+// Package schema defines Go structs that map to and from the ChargePoint API
+// WSDL types (using `encoding/xml` marshaling/unmarshaling rules).
+//
+// "API Guide" comments are quoted (with section numbers given before each
+// quote) verbatim from the following reference:
+//
+//     ChargePoint Web Services API Programmer’s Guide
+//     Document Part Number: 75-001102-01
+//     Document Revision: 8
+//     Revision Date: 2016-04-20
+//
+// In addition, the WSDL file that is modeled here, while unversioned, has the
+// following MD5 hash:
+//
+//     79595c612a701f4bf7e3f9d1ede2f7a9
+//
+// Note that struct and field names have been chosen for clarity of semantic
+// meaning, and not for strict equivalence with the corresponding WSDL types.
+// Struct tags are used to map each field to the corresponding XML element name.
+//
+// In addition, the schema is defined by the element names in the XSD, not the
+// XSD type names.  As such, no structs except those at the "top level" (i.e.,
+// ones mapping to elements whose parents do not uniquely identify their name)
+// should define an element name (via an `xml.Name` field), as it will always be
+// overwritten by the containing element.
+//
+// TODO(james): As a result of the recursive way that SOAP Envelope messages are
+// currently umarshaled, response types may not specify an XML namespace in
+// their `xml.Name` field.  This limitation may be resolved by using an
+// `interface{}` value for the body and using a single-pass parse, rather than
+// the current recursive/two-pass approach.
+package schema

--- a/controller/ev/chargepoint/go/schema/shed_load.go
+++ b/controller/ev/chargepoint/go/schema/shed_load.go
@@ -1,0 +1,72 @@
+package schema
+
+import (
+	"encoding/xml"
+	"math/big"
+)
+
+// API Guide: "Use this call to shed load for a single port on a station, both
+// ports on a multi-port station or a group of stations.  Only one of these
+// three options may be used in a request as follows:
+// - Group: Include the shedGroup element.
+// - Station: Include the shedStation element and either the
+//   allowedLoadPerStation or percentShedPerStation parameters within that
+//   element; omit the Ports array.
+// - Port: Include the shedStation element and the Ports array; set the
+//   allowedLoadPerStation and percentShedPerStation parameters in the
+//   shedStation element to a null value or omit them from the request."
+type ShedLoadRequest struct {
+	XMLName xml.Name `xml:"urn:dictionary:com.chargepoint.webservices shedLoad"`
+
+	ShedQuery struct {
+		ShedStationGroup *struct {
+			StationGroupID int32 `xml:"sgID"`
+
+			// These parameters apply *per station* in the station
+			// group; not to the group in aggregate.
+			AllowedLoadKW *big.Rat `xml:"allowedLoadPerStation,omitempty"`
+			PercentShed   *int32   `xml:"percentShedPerStation,omitempty"`
+		} `xml:"shedGroup,omitempty"`
+
+		ShedStation *struct {
+			StationID     string   `xml:"stationID"`
+			AllowedLoadKW *big.Rat `xml:"allowedLoadPerStation,omitempty"`
+			PercentShed   *int32   `xml:"percentShedPerStation,omitempty"`
+
+			Ports []struct {
+				PortNumber    string   `xml:"portNumber"`
+				AllowedLoadKW *big.Rat `xml:"allowedLoadPerPort"`
+				PercentShed   *int32   `xml:"percentShedPerPort"`
+			} `xml:"Ports>Port,omitempty"`
+		} `xml:"shedStation,omitempty"`
+
+		// API Guide: "Time interval in minutes.  A value of 0 indicates
+		// that there is no specified duration for which the power will
+		// be shed.
+		TimeInterval int32 `xml:"timeInterval"`
+	} `xml:"shedQuery"`
+}
+
+type ShedLoadResponse struct {
+	XMLName xml.Name `xml:"shedLoadResponse"`
+
+	commonResponseParameters
+
+	// API Guide: "A success (1) or failure (0) response code only.
+	//
+	// This field has `type="xsd:int"` in the WSDL, but is semantically
+	// boolean, and can safely be parsed as such.
+	Success bool `xml:"Success,omitempty"`
+
+	StationGroupID int32  `xml:"sgID,omitempty"`
+	StationID      string `xml:"stationID,omitempty"`
+
+	AllowedLoadKW *big.Rat `xml:"allowedLoadPerStation,omitempty"`
+	PercentShed   *int32   `xml:"percentShedPerStation,omitempty"`
+
+	Ports []struct {
+		PortNumber    string   `xml:"portNumber"`
+		AllowedLoadKW *big.Rat `xml:"allowedLoadPerPort,omitempty"`
+		PercentShed   *int32   `xml:"percentShedPerPort,omitempty"`
+	} `xml:"Ports>Port,omitempty"`
+}

--- a/controller/ev/chargepoint/go/schema/shed_load.go
+++ b/controller/ev/chargepoint/go/schema/shed_load.go
@@ -5,9 +5,9 @@ import (
 	"math/big"
 )
 
-// API Guide: "Use this call to shed load for a single port on a station, both
-// ports on a multi-port station or a group of stations.  Only one of these
-// three options may be used in a request as follows:
+// API Guide (§ 6.1): "Use this call to shed load for a single port on a
+// station, both ports on a multi-port station or a group of stations.  Only one
+// of these three options may be used in a request as follows:
 // - Group: Include the shedGroup element.
 // - Station: Include the shedStation element and either the
 //   allowedLoadPerStation or percentShedPerStation parameters within that
@@ -22,10 +22,24 @@ type ShedLoadRequest struct {
 		ShedStationGroup *struct {
 			StationGroupID int32 `xml:"sgID"`
 
-			// These parameters apply *per station* in the station
-			// group; not to the group in aggregate.
+			// Only one of the following two fields may be set.
+
+			// API Guide (§ 6.1.2): "Maximum allowed load expressed
+			// in kW.  This value is an absolute maximum and is not
+			// relative to the power being dispensed by the station.
+			// At the group level, this parameter applies to each
+			// station, not the total power for the group."
 			AllowedLoadKW *big.Rat `xml:"allowedLoadPerStation,omitempty"`
-			PercentShed   *int32   `xml:"percentShedPerStation,omitempty"`
+
+			// API Guide (§ 6.1.2): "Percentage of the power
+			// currently being dispensed by the station to shed.r
+			// For example, if the station is currently dispensing
+			// 10kW, a value of 60% will lower the power being
+			// dispensed to 4kW.  At the group level, this value
+			// applies to each station.  If a station is not
+			// dispensing any power, the output will be set to zero
+			// until the shed state is cleared."
+			PercentShed *int32 `xml:"percentShedPerStation,omitempty"`
 		} `xml:"shedGroup,omitempty"`
 
 		ShedStation *struct {
@@ -40,9 +54,9 @@ type ShedLoadRequest struct {
 			} `xml:"Ports>Port,omitempty"`
 		} `xml:"shedStation,omitempty"`
 
-		// API Guide: "Time interval in minutes.  A value of 0 indicates
-		// that there is no specified duration for which the power will
-		// be shed.
+		// API Guide (§ 6.1.2): "Time interval in minutes.  A value of 0
+		// indicates that there is no specified duration for which the
+		// power will be shed."
 		TimeInterval int32 `xml:"timeInterval"`
 	} `xml:"shedQuery"`
 }
@@ -52,7 +66,8 @@ type ShedLoadResponse struct {
 
 	commonResponseParameters
 
-	// API Guide: "A success (1) or failure (0) response code only.
+	// API Guide (§ 6.1.3): "A success (1) or failure (0) response code
+	// only."
 	//
 	// This field has `type="xsd:int"` in the WSDL, but is semantically
 	// boolean, and can safely be parsed as such.

--- a/controller/ev/chargepoint/go/soap.go
+++ b/controller/ev/chargepoint/go/soap.go
@@ -1,0 +1,144 @@
+package chargepoint
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"time"
+)
+
+type httpLogEntry struct {
+	RequestTimestamp time.Time
+	RequestMethod    string
+	RequestURL       string
+	RequestHeaders   map[string][]string `json:",omitempty"`
+	RequestBody      []byte              `json:",omitempty"`
+
+	ResponseTimestamp  time.Time
+	ResponseStatusCode int
+	ResponseHeaders    map[string][]string `json:",omitempty"`
+	ResponseBody       []byte              `json:",omitempty"`
+
+	Err error `json:",omitempty"`
+}
+
+// Issues a SOAP v1.1 request, unmarshalling the response into `respHeader` and
+// `respBody`.  Details of the HTTP request and response are written to
+// `httpLogWriter` as a JSON-serialized `httpLogEntry` (in JSONL format: one
+// line per entry).
+func soapCall(ctx context.Context, c *http.Client, url string, reqHeader, reqBody, respHeader, respBody interface{}, httpLogWriter io.Writer) error {
+	reqBytes, err := marshalEnvelope(reqHeader, reqBody)
+	if err != nil {
+		return fmt.Errorf("error marshaling request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(reqBytes))
+	if err != nil {
+		return fmt.Errorf("error creating HTTP request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "text/xml; charset=utf-8")
+
+	logEntry := &httpLogEntry{
+		RequestTimestamp: time.Now(),
+		RequestMethod:    httpReq.Method,
+		RequestURL:       httpReq.URL.String(),
+		RequestHeaders:   httpReq.Header,
+		RequestBody:      reqBytes,
+	}
+	defer func() {
+		if b, err := json.Marshal(logEntry); err != nil {
+			log.Printf("error marshaling HTTP log entry: %s", err)
+		} else if _, err := httpLogWriter.Write(append(b, '\n')); err != nil {
+			log.Printf("error writing HTTP log entry: %s", err)
+		}
+	}()
+
+	httpResp, err := c.Do(httpReq)
+	logEntry.ResponseTimestamp = time.Now()
+	if httpResp != nil {
+		logEntry.ResponseStatusCode = httpResp.StatusCode
+	}
+	if err != nil {
+		logEntry.Err = fmt.Errorf("error executing HTTP request: %w", err)
+		return logEntry.Err
+	}
+	defer httpResp.Body.Close()
+
+	respBytes, err := ioutil.ReadAll(httpResp.Body)
+	if err != nil {
+		logEntry.Err = fmt.Errorf("error reading HTTP response body: %w", err)
+		return logEntry.Err
+	}
+	logEntry.ResponseBody = respBytes
+
+	if httpResp.StatusCode != http.StatusOK {
+		logEntry.Err = fmt.Errorf("received non-200 response: %s", httpResp.Status)
+		return logEntry.Err
+	}
+
+	if err := unmarshalEnvelope(respBytes, respHeader, respBody); err != nil {
+		logEntry.Err = fmt.Errorf("error unmarshaling response: %w", err)
+		return logEntry.Err
+	}
+	return nil
+}
+
+// envelope is a struct representation of a SOAP v1.1 "Envelope" message, which
+// can be marshalled and unmarshalled to/from valid SOAP requests and responses.
+type envelope struct {
+	XMLName xml.Name `xml:"http://schemas.xmlsoap.org/soap/envelope/ Envelope"`
+
+	Header struct {
+		InnerXML []byte `xml:",innerxml"`
+	} `xml:"Header"`
+	Body struct {
+		InnerXML []byte `xml:",innerxml"`
+	} `xml:"Body"`
+}
+
+func marshalEnvelope(header, body interface{}) (b []byte, err error) {
+	envelope := &envelope{}
+
+	envelope.Header.InnerXML, err = xml.Marshal(header)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling SOAP header: %w", err)
+	}
+	envelope.Body.InnerXML, err = xml.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling SOAP body: %w", err)
+	}
+
+	b, err = xml.Marshal(envelope)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling SOAP envelope: %w", err)
+	}
+	return b, err
+}
+
+func unmarshalEnvelope(b []byte, header, body interface{}) error {
+	envelope := &envelope{}
+	if err := xml.Unmarshal(b, envelope); err != nil {
+		return fmt.Errorf("error unmarshalling SOAP envelope: %w", err)
+	}
+
+	if (header == nil) != (envelope.Header.InnerXML == nil) {
+		return errors.New("`header` and the SOAP header must both be `nil`, or both be specified")
+	} else if envelope.Header.InnerXML != nil {
+		if err := xml.Unmarshal(envelope.Header.InnerXML, &header); err != nil {
+			return fmt.Errorf("error unmarshalling SOAP header: %w", err)
+		}
+	}
+
+	if err := xml.Unmarshal(envelope.Body.InnerXML, &body); err != nil {
+		return fmt.Errorf("error unmarshalling SOAP body: %w", err)
+	}
+
+	return nil
+}

--- a/controller/ev/chargepoint/go/soap_test.go
+++ b/controller/ev/chargepoint/go/soap_test.go
@@ -64,11 +64,11 @@ func TestSOAPCall(t *testing.T) {
 	}
 }
 
-const envelopeXML = `<Envelope xmlns="http://schemas.xmlsoap.org/soap/envelope/"><Header><string>header</string></Header><Body><string>body</string></Body></Envelope>`
+const envelopeXML = `<Envelope xmlns="http://schemas.xmlsoap.org/soap/envelope/"><Header><string>foo</string></Header><Body><string>bar</string></Body></Envelope>`
 
 func TestMarshalUnmarshal(t *testing.T) {
-	header := "header"
-	body := "body"
+	header := "foo"
+	body := "bar"
 
 	b, err := marshalEnvelope(&header, &body)
 	if err != nil {

--- a/controller/ev/chargepoint/go/soap_test.go
+++ b/controller/ev/chargepoint/go/soap_test.go
@@ -1,0 +1,88 @@
+package chargepoint
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestSOAPCall(t *testing.T) {
+	// Create an HTTP server for testing.  This binds to a random port on
+	// the loopback interface, the address of which can be retrieved as
+	// `server.URL`.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if b, err := marshalEnvelope("respHeader", "respBody"); err != nil {
+			// There is no simple way to propogate this error to the
+			// calling code, so just panic.
+			panic(err)
+		} else if _, err := w.Write(b); err != nil {
+			panic(err)
+		}
+	}))
+	defer server.Close()
+
+	// Issue a SOAP request against the HTTP server created above, and make
+	// sure that the response is umarshalled correctly.
+	var respHeader, respBody string
+	var httpLog bytes.Buffer
+	if err := soapCall(context.Background(), &http.Client{}, server.URL, "reqHeader", "reqBody", &respHeader, &respBody, &httpLog); err != nil {
+		t.Errorf("soapCall() = %q; want nil", err)
+	} else if respHeader != "respHeader" || respBody != "respBody" {
+		t.Errorf("respHeader = %q, respBody = %q; want %q and %q", respHeader, respBody, "respHeader", "respBody")
+	}
+
+	var logEntry httpLogEntry
+	if err := json.Unmarshal(httpLog.Bytes(), &logEntry); err != nil {
+		t.Errorf("json.Unmarshal(%q) = %q; want nil", httpLog.Bytes(), err)
+	}
+
+	expectedReqBody, _ := marshalEnvelope("reqHeader", "reqBody")
+	expectedRespBody, _ := marshalEnvelope("respHeader", "respBody")
+
+	// Validate the log entry that was written to the HTTP log strream.
+	expectedLogEntry := httpLogEntry{
+		RequestTimestamp:   time.Now(),
+		RequestMethod:      "POST",
+		RequestURL:         server.URL,
+		RequestHeaders:     http.Header{"Content-Type": {"text/xml; charset=utf-8"}},
+		RequestBody:        expectedReqBody,
+		ResponseTimestamp:  time.Now(),
+		ResponseStatusCode: 200,
+		ResponseHeaders:    nil,
+		ResponseBody:       expectedRespBody,
+		Err:                nil,
+	}
+	if diff := cmp.Diff(&expectedLogEntry, &logEntry, cmp.Options{cmpopts.EquateApproxTime(time.Second)}); diff != "" {
+		t.Errorf("log entry mismatch (-want +got):\n%s", diff)
+	}
+}
+
+const envelopeXML = `<Envelope xmlns="http://schemas.xmlsoap.org/soap/envelope/"><Header><string>header</string></Header><Body><string>body</string></Body></Envelope>`
+
+func TestMarshalUnmarshal(t *testing.T) {
+	header := "header"
+	body := "body"
+
+	b, err := marshalEnvelope(&header, &body)
+	if err != nil {
+		t.Errorf("marshalEnvelope(%#v, %#v) = %q; want nil", &header, &body, err)
+	} else if diff := cmp.Diff(envelopeXML, string(b)); diff != "" {
+		t.Errorf("marshalEnvelope(%#v, %#v) mismatch (-want +got):\n%s", &header, &body, diff)
+	}
+
+	var parsedHeader, parsedBody string
+	if err := unmarshalEnvelope(b, &parsedHeader, &parsedBody); err != nil {
+		t.Errorf("unmarshalEnvelope(%q) = %q; want nil", string(b), err)
+	} else if diff := cmp.Diff(header, parsedHeader); diff != "" {
+		t.Errorf("unmarshalEnvelope(%q) mismatch (-want +got):\n%s", string(b), diff)
+	} else if diff := cmp.Diff(body, parsedBody); diff != "" {
+		t.Errorf("unmarshalEnvelope(%q) mismatch (-want +got):\n%s", string(b), diff)
+	}
+}

--- a/controller/ev/chargepoint/go/wss.go
+++ b/controller/ev/chargepoint/go/wss.go
@@ -1,0 +1,33 @@
+package chargepoint
+
+import "encoding/xml"
+
+// securityHeader is a WS-Security ("WSS") "Security" message, to be used as a
+// SOAP Header, that embeds a "UsernameToken" as the means of authentication.
+type securityHeader struct {
+	XMLName xml.Name `xml:"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd Security"`
+
+	// Must always be "1".
+	// https://www.w3.org/TR/2000/NOTE-SOAP-20000508/#_Toc478383500
+	MustUnderstand uint8 `xml:"http://schemas.xmlsoap.org/soap/envelope/ mustUnderstand,attr"`
+
+	Username string `xml:"UsernameToken>Username"`
+	Password struct {
+		Type  string `xml:"Type,attr"`
+		Value string `xml:",chardata"`
+	} `xml:"UsernameToken>Password"`
+}
+
+const passwordTypeText = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText"
+
+func newSecurityHeader(username, passwordValue string) *securityHeader {
+	out := &securityHeader{
+		MustUnderstand: 1,
+		Username:       username,
+	}
+	// Use field assignment instead of a struct literal here to avoid
+	// repeating the type definition for the `Password` field.
+	out.Password.Type = passwordTypeText
+	out.Password.Value = passwordValue
+	return out
+}

--- a/controller/ev/chargepoint/go/wss_test.go
+++ b/controller/ev/chargepoint/go/wss_test.go
@@ -1,0 +1,19 @@
+package chargepoint
+
+import (
+	"encoding/xml"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+const headerXML = `<Security xmlns="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:envelope="http://schemas.xmlsoap.org/soap/envelope/" envelope:mustUnderstand="1"><UsernameToken><Username>username</Username><Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText">password</Password></UsernameToken></Security>`
+
+func TestMarshalSecurityHeader(t *testing.T) {
+	header := newSecurityHeader("username", "password")
+	if b, err := xml.Marshal(header); err != nil {
+		t.Errorf("xml.Marshal(header) = %q; want nil", err)
+	} else if diff := cmp.Diff(headerXML, string(b)); diff != "" {
+		t.Errorf("newSecurityHeader(\"username\", \"password\") mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.3.5
+	github.com/google/go-cmp v0.4.0
 	github.com/grpc-ecosystem/grpc-gateway v1.14.3
 	golang.org/x/net v0.0.0-20200319234117-63522dbf7eec // indirect
 	golang.org/x/sys v0.0.0-20200317113312-5766fd39f98d // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/golang/protobuf v1.3.5 h1:F768QJ1E9tib+q5Sc8MkdJi1RxLTbRcTf8LJV56aRls
 github.com/golang/protobuf v1.3.5/go.mod h1:6O5/vntMXwX2lRkT1hjjk0nAC1IDOTvTlVgjlRvqsdk=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
+github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/grpc-ecosystem/grpc-gateway v1.13.0 h1:sBDQoHXrOlfPobnKw69FIKa1wg9qsLLvvQ/Y19WtFgI=
 github.com/grpc-ecosystem/grpc-gateway v1.13.0/go.mod h1:8XEsbTttt/W+VvjtQhLACqCisSPWTxCZ7sBRjU6iH9c=
 github.com/grpc-ecosystem/grpc-gateway v1.14.1 h1:YuM9SXYy583fxvSOkzCDyBPCtY+/IMSHEG1dKFMLZsA=
@@ -65,6 +67,8 @@ golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=


### PR DESCRIPTION
Apologies for the length, but most of it comes from the structs used the marshal and unmarshal the XML.

ChargePoint API Guide: https://drive.google.com/open?id=10NLpqb06wbmPES9pcdBkXDWMUInLx233
ChargePoint API WSDL: https://webservices.chargepoint.com/cp_api_5.0.wsdl
(I have also uploaded the WSDL file for reference: https://drive.google.com/file/d/1EyT0YZmlGi1swREY5zDMc-ZwDPsZWVkj/view.)

Also includes a tool for issuing requests against the ChargePoint API from the command line:

```bash
> go build ./cmd/client

> cat credentials.json
{
  "APIKey": "<SNIP>",
  "APIPassword": "<SNIP>"
}

> ./client \
    --credentials="credentials.json" \
    --http_log="http_log.jsonl" \
    --url="<API_URL>" \
    --method="GetCPNInstances" \
    --request="{}" \
    | jq
2020/05/11 22:31:20 Using request: &schema.GetCPNInstancesRequest{XMLName:xml.Name{Space:"", Local:""}}
{
  "XMLName": {
    "Space": "ns1",
    "Local": "getCPNInstancesResponse"
  },
  "ChargePointNetworks": [
    {
      "ChargePointNetworkID": "1",
      "ChargePointNetworkName": "NA",
      "ChargePointNetworkDescription": "ChargePoint Operations"
    },
    {
      "ChargePointNetworkID": "2",
      "ChargePointNetworkName": "EU",
      "ChargePointNetworkDescription": "ChargePoint Europe"
    },
    {
      "ChargePointNetworkID": "3",
      "ChargePointNetworkName": "AU",
      "ChargePointNetworkDescription": "ChargePoint Australia"
    },
    {
      "ChargePointNetworkID": "4",
      "ChargePointNetworkName": "CA",
      "ChargePointNetworkDescription": "ChargePoint Canada"
    }
  ]
}
```

The HTTP log is written in JSONL format (details are in `soap.go`), and so can also be inspected with `jq`:
```bash
> jq '(.RequestBody, .ResponseBody) |= @base64d' < http_log.jsonl
{
  "RequestTimestamp": "2020-05-11T22:31:20.736844-07:00",
  "RequestMethod": "POST",
  "RequestURL": "https://webservices.chargepoint.com/webservices/chargepoint/services/5.0",
  "RequestHeaders": {
    "Content-Type": [
      "text/xml; charset=utf-8"
    ]
  },
  "RequestBody": "<Envelope xmlns=\"http://schemas.xmlsoap.org/soap/envelope/\"><Header><Security xmlns=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\" xmlns:envelope=\"http://schemas.xmlsoap.org/soap/envelope/\" envelope:mustUnderstand=\"1\"><UsernameToken><Username>{{SNIP}}</Username><Password Type=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText\">{{SNIP}}</Password></UsernameToken></Security></Header><Body><getCPNInstances xmlns=\"urn:dictionary:com.chargepoint.webservices\"></getCPNInstances></Body></Envelope>",
  "ResponseTimestamp": "2020-05-11T22:31:21.140106-07:00",
  "ResponseStatusCode": 200,
  "ResponseBody": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:ns1=\"urn:dictionary:com.chargepoint.webservices\"><SOAP-ENV:Body><ns1:getCPNInstancesResponse><CPN><cpnID>1</cpnID><cpnName>NA</cpnName><cpnDescription>ChargePoint Operations</cpnDescription></CPN><CPN><cpnID>2</cpnID><cpnName>EU</cpnName><cpnDescription>ChargePoint Europe</cpnDescription></CPN><CPN><cpnID>3</cpnID><cpnName>AU</cpnName><cpnDescription>ChargePoint Australia</cpnDescription></CPN><CPN><cpnID>4</cpnID><cpnName>CA</cpnName><cpnDescription>ChargePoint Canada</cpnDescription></CPN></ns1:getCPNInstancesResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>\n"
}
```

`xmllint` can be used to pretty-print the XML:
```console
$ jq '(.RequestBody, .ResponseBody) |= @base64d | .ResponseBody' --raw-output \
    < http_log.jsonl \
    | xmllint --format -
<?xml version="1.0" encoding="UTF-8"?>
<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="urn:dictionary:com.chargepoint.webservices">
  <SOAP-ENV:Body>
    <ns1:getCPNInstancesResponse>
      <CPN>
        <cpnID>1</cpnID>
        <cpnName>NA</cpnName>
        <cpnDescription>ChargePoint Operations</cpnDescription>
      </CPN>
      <CPN>
        <cpnID>2</cpnID>
        <cpnName>EU</cpnName>
        <cpnDescription>ChargePoint Europe</cpnDescription>
      </CPN>
      <CPN>
        <cpnID>3</cpnID>
        <cpnName>AU</cpnName>
        <cpnDescription>ChargePoint Australia</cpnDescription>
      </CPN>
      <CPN>
        <cpnID>4</cpnID>
        <cpnName>CA</cpnName>
        <cpnDescription>ChargePoint Canada</cpnDescription>
      </CPN>
    </ns1:getCPNInstancesResponse>
  </SOAP-ENV:Body>
</SOAP-ENV:Envelope>
```