### PR TITLE
Changes in ChargePoint client API library to fit the server side use case

### DIFF
--- a/controller/ev/chargepoint/go/client.go
+++ b/controller/ev/chargepoint/go/client.go
@@ -34,7 +34,7 @@ type client struct {
 func NewClient(url, apiKey, apiPassword string, httpLogWriter io.Writer) *client {
 	return &client{
 		url:            url,
-		securityHeader: newSecurityHeader(apiKey, apiPassword),
+		securityHeader: NewSecurityHeader(apiKey, apiPassword),
 		httpClient:     http.DefaultClient,
 		httpLogWriter:  httpLogWriter,
 	}

--- a/controller/ev/chargepoint/go/soap.go
+++ b/controller/ev/chargepoint/go/soap.go
@@ -34,7 +34,7 @@ type httpLogEntry struct {
 // `httpLogWriter` as a JSON-serialized `httpLogEntry` (in JSONL format: one
 // line per entry).
 func soapCall(ctx context.Context, c *http.Client, url string, reqHeader, reqBody, respHeader, respBody interface{}, httpLogWriter io.Writer) error {
-	reqBytes, err := marshalEnvelope(reqHeader, reqBody)
+	reqBytes, err := MarshalEnvelope(reqHeader, reqBody)
 	if err != nil {
 		return fmt.Errorf("error marshaling request: %w", err)
 	}
@@ -83,7 +83,7 @@ func soapCall(ctx context.Context, c *http.Client, url string, reqHeader, reqBod
 		return logEntry.Err
 	}
 
-	if err := unmarshalEnvelope(respBytes, respHeader, respBody); err != nil {
+	if err := UnmarshalEnvelope(respBytes, respHeader, respBody); err != nil {
 		logEntry.Err = fmt.Errorf("error unmarshaling response: %w", err)
 		return logEntry.Err
 	}
@@ -103,7 +103,7 @@ type envelope struct {
 	} `xml:"Body"`
 }
 
-func marshalEnvelope(header, body interface{}) (b []byte, err error) {
+func MarshalEnvelope(header, body interface{}) (b []byte, err error) {
 	envelope := &envelope{}
 
 	envelope.Header.InnerXML, err = xml.Marshal(header)
@@ -122,7 +122,7 @@ func marshalEnvelope(header, body interface{}) (b []byte, err error) {
 	return b, err
 }
 
-func unmarshalEnvelope(b []byte, header, body interface{}) error {
+func UnmarshalEnvelope(b []byte, header, body interface{}) error {
 	envelope := &envelope{}
 	if err := xml.Unmarshal(b, envelope); err != nil {
 		return fmt.Errorf("error unmarshalling SOAP envelope: %w", err)

--- a/controller/ev/chargepoint/go/soap_test.go
+++ b/controller/ev/chargepoint/go/soap_test.go
@@ -18,7 +18,7 @@ func TestSOAPCall(t *testing.T) {
 	// the loopback interface, the address of which can be retrieved as
 	// `server.URL`.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if b, err := marshalEnvelope("respHeader", "respBody"); err != nil {
+		if b, err := MarshalEnvelope("respHeader", "respBody"); err != nil {
 			// There is no simple way to propogate this error to the
 			// calling code, so just panic.
 			panic(err)
@@ -43,8 +43,8 @@ func TestSOAPCall(t *testing.T) {
 		t.Errorf("json.Unmarshal(%q) = %q; want nil", httpLog.Bytes(), err)
 	}
 
-	expectedReqBody, _ := marshalEnvelope("reqHeader", "reqBody")
-	expectedRespBody, _ := marshalEnvelope("respHeader", "respBody")
+	expectedReqBody, _ := MarshalEnvelope("reqHeader", "reqBody")
+	expectedRespBody, _ := MarshalEnvelope("respHeader", "respBody")
 
 	// Validate the log entry that was written to the HTTP log strream.
 	expectedLogEntry := httpLogEntry{
@@ -70,7 +70,7 @@ func TestMarshalUnmarshal(t *testing.T) {
 	header := "foo"
 	body := "bar"
 
-	b, err := marshalEnvelope(&header, &body)
+	b, err := MarshalEnvelope(&header, &body)
 	if err != nil {
 		t.Errorf("marshalEnvelope(%#v, %#v) = %q; want nil", &header, &body, err)
 	} else if diff := cmp.Diff(envelopeXML, string(b)); diff != "" {
@@ -78,7 +78,7 @@ func TestMarshalUnmarshal(t *testing.T) {
 	}
 
 	var parsedHeader, parsedBody string
-	if err := unmarshalEnvelope(b, &parsedHeader, &parsedBody); err != nil {
+	if err := UnmarshalEnvelope(b, &parsedHeader, &parsedBody); err != nil {
 		t.Errorf("unmarshalEnvelope(%q) = %q; want nil", string(b), err)
 	} else if diff := cmp.Diff(header, parsedHeader); diff != "" {
 		t.Errorf("unmarshalEnvelope(%q) mismatch (-want +got):\n%s", string(b), diff)

--- a/controller/ev/chargepoint/go/wss.go
+++ b/controller/ev/chargepoint/go/wss.go
@@ -20,7 +20,7 @@ type securityHeader struct {
 
 const passwordTypeText = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText"
 
-func newSecurityHeader(username, passwordValue string) *securityHeader {
+func NewSecurityHeader(username, passwordValue string) *securityHeader {
 	out := &securityHeader{
 		MustUnderstand: 1,
 		Username:       username,

--- a/controller/ev/chargepoint/go/wss_test.go
+++ b/controller/ev/chargepoint/go/wss_test.go
@@ -10,10 +10,10 @@ import (
 const headerXML = `<Security xmlns="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:envelope="http://schemas.xmlsoap.org/soap/envelope/" envelope:mustUnderstand="1"><UsernameToken><Username>username</Username><Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText">password</Password></UsernameToken></Security>`
 
 func TestMarshalSecurityHeader(t *testing.T) {
-	header := newSecurityHeader("username", "password")
+	header := NewSecurityHeader("username", "password")
 	if b, err := xml.Marshal(header); err != nil {
 		t.Errorf("xml.Marshal(header) = %q; want nil", err)
 	} else if diff := cmp.Diff(headerXML, string(b)); diff != "" {
-		t.Errorf("newSecurityHeader(\"username\", \"password\") mismatch (-want +got):\n%s", diff)
+		t.Errorf("NewSecurityHeader(\"username\", \"password\") mismatch (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
Few changes in ChargePoint client API library,  in order to reuse code with ChargePoint server implementation.