### PR TITLE
Simplify the SOAP Envelope (un)marshaling code

### DIFF
--- a/controller/chargepoint/api/schema/clear_shed_state.go
+++ b/controller/chargepoint/api/schema/clear_shed_state.go
@@ -29,7 +29,7 @@ type ClearShedStateRequest struct {
 }
 
 type ClearShedStateResponse struct {
-	XMLName xml.Name `xml:"clearShedStateResponse"`
+	XMLName xml.Name `xml:"urn:dictionary:com.chargepoint.webservices clearShedStateResponse"`
 
 	commonResponseParameters
 

--- a/controller/chargepoint/api/schema/get_cpn_instances.go
+++ b/controller/chargepoint/api/schema/get_cpn_instances.go
@@ -11,7 +11,7 @@ type GetCPNInstancesRequest struct {
 }
 
 type GetCPNInstancesResponse struct {
-	XMLName xml.Name `xml:"getCPNInstancesResponse"`
+	XMLName xml.Name `xml:"urn:dictionary:com.chargepoint.webservices getCPNInstancesResponse"`
 
 	ChargePointNetworks []struct {
 		ChargePointNetworkID          string `xml:"cpnID,omitempty"`

--- a/controller/chargepoint/api/schema/get_load.go
+++ b/controller/chargepoint/api/schema/get_load.go
@@ -16,7 +16,7 @@ type GetLoadRequest struct {
 }
 
 type GetLoadResponse struct {
-	XMLName xml.Name `xml:"getLoadResponse"`
+	XMLName xml.Name `xml:"urn:dictionary:com.chargepoint.webservices getLoadResponse"`
 
 	commonResponseParameters
 

--- a/controller/chargepoint/api/schema/get_station_groups.go
+++ b/controller/chargepoint/api/schema/get_station_groups.go
@@ -12,7 +12,7 @@ type GetStationGroupsRequest struct {
 }
 
 type GetStationGroupsResponse struct {
-	XMLName xml.Name `xml:"getStationGroupsResponse"`
+	XMLName xml.Name `xml:"urn:dictionary:com.chargepoint.webservices getStationGroupsResponse"`
 
 	commonResponseParameters
 

--- a/controller/chargepoint/api/schema/get_stations.go
+++ b/controller/chargepoint/api/schema/get_stations.go
@@ -137,7 +137,7 @@ type PricingSession struct {
 }
 
 type GetStationsResponse struct {
-	XMLName xml.Name `xml:"getStationsResponse"`
+	XMLName xml.Name `xml:"urn:dictionary:com.chargepoint.webservices getStationsResponse"`
 
 	commonResponseParameters
 

--- a/controller/chargepoint/api/schema/schema.go
+++ b/controller/chargepoint/api/schema/schema.go
@@ -23,10 +23,4 @@
 // ones mapping to elements whose parents do not uniquely identify their name)
 // should define an element name (via an `xml.Name` field), as it will always be
 // overwritten by the containing element.
-//
-// TODO(james): As a result of the recursive way that SOAP Envelope messages are
-// currently umarshaled, response types may not specify an XML namespace in
-// their `xml.Name` field.  This limitation may be resolved by using an
-// `interface{}` value for the body and using a single-pass parse, rather than
-// the current recursive/two-pass approach.
 package schema

--- a/controller/chargepoint/api/schema/shed_load.go
+++ b/controller/chargepoint/api/schema/shed_load.go
@@ -62,7 +62,7 @@ type ShedLoadRequest struct {
 }
 
 type ShedLoadResponse struct {
-	XMLName xml.Name `xml:"shedLoadResponse"`
+	XMLName xml.Name `xml:"urn:dictionary:com.chargepoint.webservices shedLoadResponse"`
 
 	commonResponseParameters
 


### PR DESCRIPTION
By doing the entire parse in a single pass (by using the supplied header/body values as `interface{}` values directly in the `Envelope` object), this also removes the restriction on namespaces during unmarshaling (see the diff on `schema.go`).