### PR TITLE
Fix some misspellings of "unmarshaling"

### DIFF
--- a/controller/chargepoint/api/cmd/client/main.go
+++ b/controller/chargepoint/api/cmd/client/main.go
@@ -120,7 +120,7 @@ func mainInternal() error {
 
 	// Unmarshal `--request` into `req`.
 	if err := json.Unmarshal([]byte(*request), req); err != nil {
-		return fmt.Errorf("error unmarshalling JSON request: %w", err)
+		return fmt.Errorf("error unmarshaling JSON request: %w", err)
 	}
 	log.Printf("Using request: %#v", req)
 
@@ -148,7 +148,7 @@ func mainInternal() error {
 	if !errVal.IsNil() {
 		return fmt.Errorf("error calling API: %w", errVal.Interface().(error))
 	} else if b, err := json.Marshal(respVal.Interface()); err != nil {
-		return fmt.Errorf("error marshalling response as JSON: %w", err)
+		return fmt.Errorf("error marshaling response as JSON: %w", err)
 	} else {
 		fmt.Fprintln(fd, string(b))
 	}

--- a/controller/chargepoint/api/soap.go
+++ b/controller/chargepoint/api/soap.go
@@ -28,7 +28,7 @@ type httpLogEntry struct {
 	Err error `json:",omitempty"`
 }
 
-// Issues a SOAP v1.1 request, unmarshalling the response into `respHeader` and
+// Issues a SOAP v1.1 request, unmarshaling the response into `respHeader` and
 // `respBody`.  Details of the HTTP request and response are written to
 // `httpLogWriter` as a JSON-serialized `httpLogEntry` (in JSONL format: one
 // line per entry).
@@ -119,7 +119,7 @@ func unmarshalEnvelope(b []byte, header, body interface{}) error {
 	env.Header.Payload = header
 	env.Body.Payload = body
 	if err := xml.Unmarshal(b, &env); err != nil {
-		return fmt.Errorf("error unmarshalling SOAP envelope: %w", err)
+		return fmt.Errorf("error unmarshaling SOAP envelope: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
"Marshaling" (the US spelling) is the spelling used by the standard library ([source](https://gist.github.com/powerduncan/cc761af3c0acb00bdb0dc45d927b71f3)), so I should have been consistent with that.