### PR TITLE
Eliminate the use of anonymous structs in the API schema.

### DIFF
--- a/controller/chargepoint/api/schema/clear_shed_state.go
+++ b/controller/chargepoint/api/schema/clear_shed_state.go
@@ -7,25 +7,18 @@ import "encoding/xml"
 type ClearShedStateRequest struct {
 	XMLName xml.Name `xml:"urn:dictionary:com.chargepoint.webservices clearShedState"`
 
-	ShedQuery struct {
-		StationGroup *struct {
-			StationGroupID int32 `xml:"sgID"`
-		} `xml:"shedGroup,omitempty"`
+	StationGroupID *int32 `xml:"shedQuery>shedGroup>sgID,omitempty"`
 
-		Station *struct {
-			StationID string `xml:"stationID"`
+	StationID *string `xml:"shedQuery>shedStation>stationID,omitempty"`
 
-			// This part of the API is not documented in the API
-			// Guide, but it is part of the WSDL.
-			//
-			// TODO(james): Check if this is actually implemented in
-			// the API server.  If not, it should be removed from
-			// this schema representation.
-			Ports *struct {
-				PortNumbers []string `xml:"Port>portNumber"`
-			} `xml:"Ports,omitempty"`
-		} `xml:"shedStation,omitempty"`
-	} `xml:"shedQuery"`
+	// This part of the API is not documented in the API Guide, but it is
+	// part of the WSDL.
+	//
+	// Note that `StationID` is required if `PortNumbers` is specified.
+	//
+	// TODO(james): Check if this is actually implemented in the API server.
+	// If not, it should be removed from this schema representation.
+	PortNumbers []string `xml:"shedQuery>shedStation>Ports>Port>portNumber,omitempty"`
 }
 
 type ClearShedStateResponse struct {

--- a/controller/chargepoint/api/schema/get_cpn_instances.go
+++ b/controller/chargepoint/api/schema/get_cpn_instances.go
@@ -13,9 +13,11 @@ type GetCPNInstancesRequest struct {
 type GetCPNInstancesResponse struct {
 	XMLName xml.Name `xml:"urn:dictionary:com.chargepoint.webservices getCPNInstancesResponse"`
 
-	ChargePointNetworks []struct {
-		ChargePointNetworkID          string `xml:"cpnID,omitempty"`
-		ChargePointNetworkName        string `xml:"cpnName,omitempty"`
-		ChargePointNetworkDescription string `xml:"cpnDescription,omitempty"`
-	} `xml:"CPN,omitempty"`
+	ChargePointNetworks []GetCPNInstancesResponse_ChargePointNetwork `xml:"CPN,omitempty"`
+}
+
+type GetCPNInstancesResponse_ChargePointNetwork struct {
+	ID          string `xml:"cpnID,omitempty"`
+	Name        string `xml:"cpnName,omitempty"`
+	Description string `xml:"cpnDescription,omitempty"`
 }

--- a/controller/chargepoint/api/schema/get_load.go
+++ b/controller/chargepoint/api/schema/get_load.go
@@ -2,7 +2,6 @@ package schema
 
 import (
 	"encoding/xml"
-	"math/big"
 )
 
 // API Guide (§ 6.3): "Use this call to retrieve the load and shed state for a
@@ -25,42 +24,43 @@ type GetLoadResponse struct {
 	StationGroupName        string `xml:"groupName,omitempty"`
 	StationGroupLoadKW      string `xml:"sgLoad,omitempty"`
 
-	Stations []struct {
-		StationID      string  `xml:"stationID,omitempty"`
-		StationName    string  `xml:"stationName,omitempty"`
-		StationAddress string  `xml:"Address,omitempty"`
-		StationLoadKW  big.Rat `xml:"stationLoad,omitempty"`
+	Stations []GetLoadResponse_Station `xml:"stationData,omitempty"`
+}
 
-		Ports []struct {
-			PortNumber string `xml:"portNumber,omitempty"`
-			UserID     string `xml:"userID,omitempty"`
-			// API Guide (§ 6.3.3): "Identifier of the credential
-			// used to start the session.  If it was a ChargePoint
-			// RFID card, it is the printed serial number on the
-			// card.  If it was the ChargePoint Mobile App, it will
-			// be the identifier displayed in the user’s mobile app.
-			// Contactless credit cards will be obviously be
-			// displayed as blank."
-			CredentialID *string `xml:"credentialID,omitempty"`
+type GetLoadResponse_Station struct {
+	StationID      string `xml:"stationID,omitempty"`
+	StationName    string `xml:"stationName,omitempty"`
+	StationAddress string `xml:"Address,omitempty"`
+	StationLoadKW  string `xml:"stationLoad,omitempty"`
 
-			PortLoadKW big.Rat `xml:"portLoad,omitempty"`
+	Ports []GetLoadResponse_Station_Port `xml:"Port,omitempty"`
+}
 
-			// API Guide (§ 6.3.3): "1 = Shed, 0 = Not Shed"
-			ShedState uint8 `xml:"shedState"`
+type GetLoadResponse_Station_Port struct {
+	PortNumber string `xml:"portNumber,omitempty"`
+	UserID     string `xml:"userID,omitempty"`
+	// API Guide (§ 6.3.3): "Identifier of the credential used to start the
+	// session.  If it was a ChargePoint RFID card, it is the printed serial
+	// number on the card.  If it was the ChargePoint Mobile App, it will be
+	// the identifier displayed in the user’s mobile app.  Contactless
+	// credit cards will be obviously be displayed as blank."
+	CredentialID *string `xml:"credentialID,omitempty"`
 
-			// Only one of the following two fields should be set.
+	PortLoadKW string `xml:"portLoad,omitempty"`
 
-			// API Guide (§ 6.3.3): "Maximum load allowed at the
-			// station (kW).  If percentShed was used in the last
-			// shedLoad call to this station, this parameter will be
-			// zero."
-			AllowedLoadKW *big.Rat `xml:"allowedLoad,omitempty"`
-			// API Guide (§ 6.3.3): "Percent of load currently being
-			// shed.  If allowedLoad was used in the last shedLoad
-			// call to this station, this parameter will be zero."
-			//
-			// Percent of load currently being shed (0 - 100).
-			PercentShed *uint8 `xml:"percentShed,omitempty"`
-		} `xml:"Port,omitempty"`
-	} `xml:"stationData,omitempty"`
+	// API Guide (§ 6.3.3): "1 = Shed, 0 = Not Shed"
+	ShedState *uint8 `xml:"shedState,omitempty"`
+
+	// Only one of the following two fields should be set.
+
+	// API Guide (§ 6.3.3): "Maximum load allowed at the station (kW).  If
+	// percentShed was used in the last shedLoad call to this station, this
+	// parameter will be zero."
+	AllowedLoadKW string `xml:"allowedLoad,omitempty"`
+	// API Guide (§ 6.3.3): "Percent of load currently being shed.  If
+	// allowedLoad was used in the last shedLoad call to this station, this
+	// parameter will be zero."
+	//
+	// Percent of load currently being shed (0 - 100).
+	PercentShed *uint8 `xml:"percentShed,omitempty"`
 }

--- a/controller/chargepoint/api/schema/get_station_groups.go
+++ b/controller/chargepoint/api/schema/get_station_groups.go
@@ -16,16 +16,20 @@ type GetStationGroupsResponse struct {
 
 	commonResponseParameters
 
-	StationGroups []struct {
-		OrganizationID   string `xml:"orgID,omitempty"`
-		OrganizationName string `xml:"organizationName,omitempty"`
+	StationGroups []GetStationGroupsResponse_StationGroup `xml:"groupData,omitempty"`
+}
 
-		StationGroupID   int32  `xml:"sgID,omitempty"`
-		StationGroupName string `xml:"sgName,omitempty"`
+type GetStationGroupsResponse_StationGroup struct {
+	OrganizationID   string `xml:"orgID,omitempty"`
+	OrganizationName string `xml:"organizationName,omitempty"`
 
-		Stations []struct {
-			StationID  string      `xml:"stationID,omitempty"`
-			Coordinate *Coordinate `xml:"Geo,omitempty"`
-		} `xml:"stationData,omitempty"`
-	} `xml:"groupData,omitempty"`
+	StationGroupID   int32  `xml:"sgID,omitempty"`
+	StationGroupName string `xml:"sgName,omitempty"`
+
+	Stations []GetStationGroupsResponse_StationGroup_Station `xml:"stationData,omitempty"`
+}
+
+type GetStationGroupsResponse_StationGroup_Station struct {
+	StationID  string      `xml:"stationID,omitempty"`
+	Coordinate *Coordinate `xml:"Geo,omitempty"`
 }

--- a/controller/chargepoint/api/schema/get_stations.go
+++ b/controller/chargepoint/api/schema/get_stations.go
@@ -2,7 +2,6 @@ package schema
 
 import (
 	"encoding/xml"
-	"math/big"
 )
 
 // API Guide (§ 8.1): "Use this call to return a list of stations.  This will
@@ -14,115 +13,108 @@ import (
 type GetStationsRequest struct {
 	XMLName xml.Name `xml:"urn:dictionary:com.chargepoint.webservices getStations"`
 
-	SearchQuery struct {
-		// API Guide (§ 8.1.2): "A unique station identifier used in
-		// ChargePoint.  This identifier never changes, even when the
-		// station's head assembly is swapped.  Format:
-		// CPNID:StationIdentifier."
-		StationID           string `xml:"stationID,omitempty"`
-		StationManufacturer string `xml:"stationManufacturer,omitempty"`
-		StationModel        string `xml:"stationModel,omitempty"`
-		// API Guide (§ 8.1.2): "Name of the station (wild card
-		// characters are allowed).  It should be searched for by both
-		// company name (the name of the organization that owns the
-		// charging station) and station name.  Company name is
-		// displayed on Line 1 of the charging station (if applicable)
-		// and the station name is displayed on Line 2 of the charging
-		// station (if applicable)."
-		StationName string `xml:"stationName,omitempty"`
+	// API Guide (§ 8.1.2): "A unique station identifier used in
+	// ChargePoint.  This identifier never changes, even when the station's
+	// head assembly is swapped.  Format: CPNID:StationIdentifier."
+	StationID           string `xml:"searchQuery>stationID,omitempty"`
+	StationManufacturer string `xml:"searchQuery>stationManufacturer,omitempty"`
+	StationModel        string `xml:"searchQuery>stationModel,omitempty"`
+	// API Guide (§ 8.1.2): "Name of the station (wild card characters are
+	// allowed).  It should be searched for by both company name (the name
+	// of the organization that owns the charging station) and station name.
+	// Company name is displayed on Line 1 of the charging station (if
+	// applicable) and the station name is displayed on Line 2 of the
+	// charging station (if applicable)."
+	StationName string `xml:"searchQuery>stationName,omitempty"`
 
-		// API Guide (§ 8.1.2): "Address around which you want to see
-		// stations.  This can be street address or complete address
-		// (street address, city, state, zip code, country)."
-		Address    string `xml:"Address,omitempty"`
-		City       string `xml:"City,omitempty"`
-		State      string `xml:"State,omitempty"`
-		Country    string `xml:"Country,omitempty"`
-		PostalCode string `xml:"postalCode,omitempty"`
+	// API Guide (§ 8.1.2): "Address around which you want to see stations.
+	// This can be street address or complete address (street address, city,
+	// state, zip code, country)."
+	Address    string `xml:"searchQuery>Address,omitempty"`
+	City       string `xml:"searchQuery>City,omitempty"`
+	State      string `xml:"searchQuery>State,omitempty"`
+	Country    string `xml:"searchQuery>Country,omitempty"`
+	PostalCode string `xml:"searchQuery>postalCode,omitempty"`
 
-		Coordinate *Coordinate `xml:"Geo,omitempty"`
-		// API Guide (§ 8.1.2): "Distance from the station's specified
-		// lat/long (Geo) from which you want to retrieve station
-		// information.  Default is 5"
-		Proximity *big.Rat `xml:"Proximity,omitempty"`
-		// API Guide (§ 8.1.2): "Default value for proximity unit is M.
-		// Can have values: M (miles), N (Nautical miles), K
-		// (Kilometer), F (Feet), I (Inches)."
-		ProximityUnit string `xml:"proximityUnit,omitempty"`
+	Coordinate *Coordinate `xml:"searchQuery>Geo,omitempty"`
+	// API Guide (§ 8.1.2): "Distance from the station's specified lat/long
+	// (Geo) from which you want to retrieve station information.  Default
+	// is 5"
+	Proximity string `xml:"searchQuery>Proximity,omitempty"`
+	// API Guide (§ 8.1.2): "Default value for proximity unit is M.  Can
+	// have values: M (miles), N (Nautical miles), K (Kilometer), F (Feet),
+	// I (Inches)."
+	ProximityUnit string `xml:"searchQuery>proximityUnit,omitempty"`
 
-		// WSDL: "Possible values 1 is Level 1, 2 is Level 2, 3 is Level
-		// 1 2 ,4 is DC charger, 5 Level 1, Level2, DC charger"
-		//
-		// API Guide (§ 8.1.2): "Station level type where 1 is 'Level
-		// 1', 2 is 'Level 2', 3 is 'Level 3', and 4 is 'DC Fast'.  If a
-		// station has more than one level (for example, the station
-		// provides both level 1 and level 2 charging), the response
-		// will includ both level (1,2).  Note: This parameter is for
-		// 'US Stations' and 'AU Stations' only (and is used instead of
-		// 'Mode')."
-		Level string `xml:"Level,omitempty"`
-		// API Guide (§ 8.1.2): "Station mode type where 1 is 'Mode 1',
-		// 3 is 'Mode 3', and 4 is 'DC Fast'.  If the station has more
-		// than one mode (for example, the station provides both mode 1
-		// with a domestic socket and mode 3 charging with an IEC 62196
-		// Type 2 socket), the response will include both modes (1,3).
-		// Note: This parameter is for "EU Stations" only (and is used
-		// instead of "Level").
-		Mode string `xml:"Mode,omitempty"`
+	// WSDL: "Possible values 1 is Level 1, 2 is Level 2, 3 is Level 1 2 ,4
+	// is DC charger, 5 Level 1, Level2, DC charger"
+	//
+	// API Guide (§ 8.1.2): "Station level type where 1 is 'Level 1', 2 is
+	// 'Level 2', 3 is 'Level 3', and 4 is 'DC Fast'.  If a station has more
+	// than one level (for example, the station provides both level 1 and
+	// level 2 charging), the response will includ both level (1,2).  Note:
+	// This parameter is for 'US Stations' and 'AU Stations' only (and is
+	// used instead of 'Mode')."
+	Level string `xml:"searchQuery>Level,omitempty"`
+	// API Guide (§ 8.1.2): "Station mode type where 1 is 'Mode 1', 3 is
+	// 'Mode 3', and 4 is 'DC Fast'.  If the station has more than one mode
+	// (for example, the station provides both mode 1 with a domestic socket
+	// and mode 3 charging with an IEC 62196 Type 2 socket), the response
+	// will include both modes (1,3).  Note: This parameter is for "EU
+	// Stations" only (and is used instead of "Level").
+	Mode string `xml:"searchQuery>Mode,omitempty"`
 
-		PricingSession *PricingSession `xml:"Pricing,omitempty"`
+	PricingSession *GetStationsRequest_PricingSession `xml:"searchQuery>Pricing,omitempty"`
 
-		// API Guide (§ 8.1.2): "Whether or not the station can be
-		// reserved: '1' - the station can be reserved.  '0' - the
-		// station cannot be reserved."
-		Reservable uint8 `xml:"Reservable,omitempty"`
+	// API Guide (§ 8.1.2): "Whether or not the station can be reserved: '1'
+	// - the station can be reserved.  '0' - the station cannot be
+	// reserved."
+	Reservable uint8 `xml:"searchQuery>Reservable,omitempty"`
 
-		// API Guide (§ 8.1.2): "Connector type.  For example: NEMA
-		// 5-20R, J1772, ALFENL3, Shuko."
-		Connector string `xml:"Connector,omitempty"`
+	// API Guide (§ 8.1.2): "Connector type.  For example: NEMA 5-20R,
+	// J1772, ALFENL3, Shuko."
+	Connector string `xml:"searchQuery>Connector,omitempty"`
 
-		// API Guide (§ 8.1.2): "Nominal voltage (V)."
-		Voltage string `xml:"Voltage,omitempty"`
-		// API Guide (§ 8.1.2): "Current supported (A)."
-		Current string `xml:"Current,omitempty"`
-		// API Guide (§ 8.1.2): "Power supported (kW)."
-		PowerKW string `xml:"Power,omitempty"`
+	// API Guide (§ 8.1.2): "Nominal voltage (V)."
+	Voltage string `xml:"searchQuery>Voltage,omitempty"`
+	// API Guide (§ 8.1.2): "Current supported (A)."
+	Current string `xml:"searchQuery>Current,omitempty"`
+	// API Guide (§ 8.1.2): "Power supported (kW)."
+	PowerKW string `xml:"searchQuery>Power,omitempty"`
 
-		// API Guide (§ 8.1.2): "Array of serial numbers of stations
-		// identified as a 'demo'.  Used only for client applications
-		// that need to access stations identified as 'demo'.
-		DemoStations *struct {
-			SerialNumbers []string `xml:"serialNumber"`
-		} `xml:"demoSerialNumber,omitempty"`
+	// API Guide (§ 8.1.2): "Array of serial numbers of stations identified
+	// as a 'demo'.  Used only for client applications that need to access
+	// stations identified as 'demo'.
+	DemoStationSerialNumbers []string `xml:"searchQuery>demoSerialNumber>serialNumber,omitempty"`
 
-		// API Guide (§ 8.1.2): "The org identifier CPNID:CompanyID"
-		OrganizationID   string `xml:"orgID,omitempty"`
-		OrganizationName string `xml:"organizationName,omitempty"`
-		StationGroupID   string `xml:"sgID,omitempty"`
-		StationGroupName string `xml:"sgName,omitempty"`
+	// API Guide (§ 8.1.2): "The org identifier CPNID:CompanyID"
+	OrganizationID   string `xml:"searchQuery>orgID,omitempty"`
+	OrganizationName string `xml:"searchQuery>organizationName,omitempty"`
+	StationGroupID   string `xml:"searchQuery>sgID,omitempty"`
+	StationGroupName string `xml:"searchQuery>sgName,omitempty"`
 
-		// API Guide (§ 8.1.2): "Start index for the stations that match
-		// the query."
-		StartRecord int32 `xml:"startRecord,omitempty"`
-		// API Guide (§ 8.1.2): "Number of stations to return in the
-		// response.  Maximum is 500, and if left blank, the method will
-		// return up to 500 stations."
-		NumRecords int32 `xml:"numStations,omitempty"`
+	// API Guide (§ 8.1.2): "Start index for the stations that match the
+	// query."
+	StartRecord int32 `xml:"searchQuery>startRecord,omitempty"`
+	// API Guide (§ 8.1.2): "Number of stations to return in the response.
+	// Maximum is 500, and if left blank, the method will return up to 500
+	// stations."
+	NumRecords int32 `xml:"searchQuery>numStations,omitempty"`
 
-		// Undocumented in the API Guide, but exist in the WSDL.
-		SerialNumber          string      `xml:"serialNumber,omitempty"`
-		StationActivationDate xsdDateTime `xml:"stationActivationDate,omitempty"`
-	} `xml:"searchQuery"`
+	// Undocumented in the API Guide, but exist in the WSDL.
+	SerialNumber          string      `xml:"searchQuery>serialNumber,omitempty"`
+	StationActivationDate xsdDateTime `xml:"searchQuery>stationActivationDate,omitempty"`
 }
 
-type PricingSession struct {
+type GetStationsRequest_PricingSession struct {
 	StartTime xsdTime `xml:"startTime"`
 
 	// WSDL: "Expected duration of charging session in minutes."
 	//
 	// API Guide (§ 8.1.2): "Estimated duration of session in hours"
 	ExpectedDurationMinutes int32 `xml:"Duration"`
-	// API Guide (§ 8.1.2): "Estimated energy needed for a charging session in kWh."
+	// API Guide (§ 8.1.2): "Estimated energy needed for a charging session
+	// in kWh."
 	ExpectedDurationKWh float64 `xml:"energyRequired"`
 
 	// This field is part of the XSD type used by "getStations", but is not
@@ -141,49 +133,7 @@ type GetStationsResponse struct {
 
 	commonResponseParameters
 
-	Stations []struct {
-		StationID           string `xml:"stationID,omitempty"`
-		StationManufacturer string `xml:"stationManufacturer,omitempty"`
-		StationModel        string `xml:"stationModel,omitempty"`
-		StationMACAddress   string `xml:"stationMacAddr,omitempty"`
-		StationSerialNumber string `xml:"stationSerialNum,omitempty"`
-
-		StationGroupID   string `xml:"sgID,omitempty"`
-		StationGroupName string `xml:"sgName,omitempty"`
-		OrganizationID   string `xml:"orgID"`
-		OrganizationName string `xml:"organizationName"`
-
-		// API Guide (§ 8.1.3): "Complete address (street address, city,
-		// state, zip code, country)."
-		Address    string `xml:"Address,omitempty"`
-		City       string `xml:"City,omitempty"`
-		State      string `xml:"State,omitempty"`
-		Country    string `xml:"Country,omitempty"`
-		PostalCode string `xml:"postalCode,omitempty"`
-
-		NumPorts int32  `xml:"numPorts,omitempty"`
-		Ports    []Port `xml:"Port,omitempty"`
-
-		// API Guide (§ 8.1.3): "The ISO 4217 code for the currency used
-		// on the station.  For eample, US Dollar = USD, Canadian Dollar
-		// = CAD, Euro = EUR."
-		CurrencyCode string `xml:"currencyCode,omitempty"`
-
-		// `maxOccurs` for this element in the WSDL is 2.
-		PricingSpecification []PricingSpecification `xml:"Pricing,omitempty"`
-
-		DriverSupportPhoneNumber string `xml:"mainPhone,omitempty"`
-
-		// Undocumented in the API Guide, but exist in the WSDL.
-		StationActivationDate xsdDateTime `xml:"stationActivationDate,omitempty"`
-		DriverName            string      `xml:"driverName,omitempty"`
-		DriverAddress         string      `xml:"driverAddress,omitempty"`
-		DriverEmail           string      `xml:"driverEmail,omitempty"`
-		DriverPhoneNumber     string      `xml:"driverPhoneNumber,omitempty"`
-		LastModifiedDate      xsdDateTime `xml:"lastModifiedDate,omitempty"`
-		ModTimeStamp          xsdDateTime `xml:"modTimeStamp,omitempty"`
-		TimezoneOffset        string      `xml:"timezoneOffset,omitempty"`
-	} `xml:"stationData,omitempty"`
+	Stations []GetStationsResponse_Station `xml:"stationData,omitempty"`
 
 	// API Guide (§ 8.1.3): "Indicates that the number of stations that
 	// match this query is greater than the maximum number of stations that
@@ -196,7 +146,72 @@ type GetStationsResponse struct {
 	Truncated bool `xml:"moreFlag,omitempty"`
 }
 
-type PricingSpecification struct {
+type GetStationsResponse_Station struct {
+	StationID           string `xml:"stationID,omitempty"`
+	StationManufacturer string `xml:"stationManufacturer,omitempty"`
+	StationModel        string `xml:"stationModel,omitempty"`
+	StationMACAddress   string `xml:"stationMacAddr,omitempty"`
+	StationSerialNumber string `xml:"stationSerialNum,omitempty"`
+
+	StationGroupID   string `xml:"sgID,omitempty"`
+	StationGroupName string `xml:"sgName,omitempty"`
+	OrganizationID   string `xml:"orgID"`
+	OrganizationName string `xml:"organizationName"`
+
+	// API Guide (§ 8.1.3): "Complete address (street address, city, state,
+	// zip code, country)."
+	Address    string `xml:"Address,omitempty"`
+	City       string `xml:"City,omitempty"`
+	State      string `xml:"State,omitempty"`
+	Country    string `xml:"Country,omitempty"`
+	PostalCode string `xml:"postalCode,omitempty"`
+
+	NumPorts int32                              `xml:"numPorts,omitempty"`
+	Ports    []GetStationsResponse_Station_Port `xml:"Port,omitempty"`
+
+	// API Guide (§ 8.1.3): "The ISO 4217 code for the currency used on the
+	// station.  For eample, US Dollar = USD, Canadian Dollar = CAD, Euro =
+	// EUR."
+	CurrencyCode string `xml:"currencyCode,omitempty"`
+
+	// `maxOccurs` for this element in the WSDL is 2.
+	PricingSpecification []GetStationsResponse_Station_PricingSpecification `xml:"Pricing,omitempty"`
+
+	DriverSupportPhoneNumber string `xml:"mainPhone,omitempty"`
+
+	// Undocumented in the API Guide, but exist in the WSDL.
+	StationActivationDate xsdDateTime `xml:"stationActivationDate,omitempty"`
+	DriverName            string      `xml:"driverName,omitempty"`
+	DriverAddress         string      `xml:"driverAddress,omitempty"`
+	DriverEmail           string      `xml:"driverEmail,omitempty"`
+	DriverPhoneNumber     string      `xml:"driverPhoneNumber,omitempty"`
+	LastModifiedDate      xsdDateTime `xml:"lastModifiedDate,omitempty"`
+	ModTimeStamp          xsdDateTime `xml:"modTimeStamp,omitempty"`
+	TimezoneOffset        string      `xml:"timezoneOffset,omitempty"`
+}
+
+type GetStationsResponse_Station_Port struct {
+	// API Guide (§ 8.1.3): "Identifier of the port.  This ID is 1 based."
+	PortNumber string `xml:"portNumber,omitempty"`
+
+	StationName string      `xml:"stationName,omitempty"`
+	Coordinate  *Coordinate `xml:"Geo,omitempty"`
+	Reservable  uint8       `xml:"Reservable,omitempty"`
+	Level       string      `xml:"Level,omitempty"`
+	Mode        string      `xml:"Mode,omitempty"`
+	Connector   string      `xml:"Connector,omitempty"`
+	Voltage     string      `xml:"Voltage,omitempty"`
+	Current     string      `xml:"Current,omitempty"`
+	PowerKW     string      `xml:"Power,omitempty"`
+
+	// Undocumented in the API Guide, but exist in the WSDL
+	Description   string      `xml:"Desription,omitempty"`
+	Status        string      `xml:"Status,omitempty"`
+	Timestamp     xsdDateTime `xml:"timeStamp,omitempty"`
+	EstimatedCost float64     `xml:"estimatedCost,omitempty"`
+}
+
+type GetStationsResponse_Station_PricingSpecification struct {
 	// API Guide (§ 8.1.3): "Pricing Type (Session, Hourly, or kWh)"
 	Type string `xml:"Type,omitempty"`
 
@@ -238,25 +253,4 @@ type PricingSpecification struct {
 	// API Guide (§ 8.1.3): "The hourly price for the second portion of the
 	// pricing specification if pricing varies by length of time"
 	UnitPricePerHourThereafter float64 `xml:"unitPricePerHourThereafter,omitempty"`
-}
-
-type Port struct {
-	// API Guide (§ 8.1.3): "Identifier of the port.  This ID is 1 based."
-	PortNumber string `xml:"portNumber,omitempty"`
-
-	StationName string      `xml:"stationName,omitempty"`
-	Coordinate  *Coordinate `xml:"Geo,omitempty"`
-	Reservable  uint8       `xml:"Reservable,omitempty"`
-	Level       string      `xml:"Level,omitempty"`
-	Mode        string      `xml:"Mode,omitempty"`
-	Connector   string      `xml:"Connector,omitempty"`
-	Voltage     string      `xml:"Voltage,omitempty"`
-	Current     string      `xml:"Current,omitempty"`
-	PowerKW     string      `xml:"Power,omitempty"`
-
-	// Undocumented in the API Guide, but exist in the WSDL
-	Description   string      `xml:"Desription,omitempty"`
-	Status        string      `xml:"Status,omitempty"`
-	Timestamp     xsdDateTime `xml:"timeStamp,omitempty"`
-	EstimatedCost float64     `xml:"estimatedCost,omitempty"`
 }

--- a/controller/chargepoint/api/schema/schema_test.go
+++ b/controller/chargepoint/api/schema/schema_test.go
@@ -1,0 +1,291 @@
+package schema
+
+import (
+	"encoding/xml"
+	"regexp"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func newInt32(x int32) *int32 { return &x }
+
+func newString(x string) *string { return &x }
+
+func TestMarshal(t *testing.T) {
+	envelopeRE := regexp.MustCompile(`\s*<`)
+
+	for name, tt := range map[string]struct {
+		Value    interface{}
+		Expected string
+	}{
+		"ClearShedStateRequest_StationGroupID": {
+			&ClearShedStateRequest{
+				StationGroupID: newInt32(1234),
+			},
+			`<clearShedState xmlns="urn:dictionary:com.chargepoint.webservices">
+			  <shedQuery>
+			    <shedGroup>
+			      <sgID>1234</sgID>
+			    </shedGroup>
+			    <shedStation>
+			      <Ports>
+				<Port></Port>
+			      </Ports>
+			    </shedStation>
+			  </shedQuery>
+			</clearShedState>`,
+		},
+		"ClearShedStateRequest_StationID": {
+			&ClearShedStateRequest{
+				StationID: newString("station id"),
+			},
+			`<clearShedState xmlns="urn:dictionary:com.chargepoint.webservices">
+			  <shedQuery>
+			    <shedStation>
+			      <stationID>station id</stationID>
+			      <Ports>
+				<Port></Port>
+			      </Ports>
+			    </shedStation>
+			  </shedQuery>
+			</clearShedState>`,
+		},
+		"ClearShedStateRequest_PortNumbers": {
+			&ClearShedStateRequest{
+				StationID:   newString("station id"),
+				PortNumbers: []string{"0", "1"},
+			},
+			`<clearShedState xmlns="urn:dictionary:com.chargepoint.webservices">
+			  <shedQuery>
+			    <shedStation>
+			      <stationID>station id</stationID>
+			      <Ports>
+				<Port>
+				  <portNumber>0</portNumber>
+				  <portNumber>1</portNumber>
+				</Port>
+			      </Ports>
+			    </shedStation>
+			  </shedQuery>
+			</clearShedState>`,
+		},
+
+		"GetCPNInstancesResponse": {
+			&GetCPNInstancesResponse{
+				ChargePointNetworks: []GetCPNInstancesResponse_ChargePointNetwork{
+					{ID: "network id", Name: "network name", Description: "description"},
+				},
+			},
+			`<getCPNInstancesResponse xmlns="urn:dictionary:com.chargepoint.webservices">
+			  <CPN>
+			    <cpnID>network id</cpnID>
+			    <cpnName>network name</cpnName>
+			    <cpnDescription>description</cpnDescription>
+			  </CPN>
+			</getCPNInstancesResponse>`,
+		},
+
+		"GetLoadResponse": {
+			&GetLoadResponse{
+				StationGroupID:          int32(1234),
+				StationGroupNumStations: int32(1),
+				StationGroupName:        "station group name",
+				StationGroupLoadKW:      "0.5",
+				Stations: []GetLoadResponse_Station{
+					{
+						StationID:      "station id",
+						StationName:    "station name",
+						StationAddress: "station address",
+						StationLoadKW:  "0.5",
+						Ports: []GetLoadResponse_Station_Port{
+							{PortNumber: "0", UserID: "user id"},
+						},
+					},
+				},
+			},
+			`<getLoadResponse xmlns="urn:dictionary:com.chargepoint.webservices">
+			  <responseCode></responseCode>
+			  <sgID>1234</sgID>
+			  <numStations>1</numStations>
+			  <groupName>station group name</groupName>
+			  <sgLoad>0.5</sgLoad>
+			  <stationData>
+			    <stationID>station id</stationID>
+			    <stationName>station name</stationName>
+			    <Address>station address</Address>
+			    <stationLoad>0.5</stationLoad>
+			    <Port>
+			      <portNumber>0</portNumber>
+			      <userID>user id</userID>
+			    </Port>
+			  </stationData>
+			</getLoadResponse>`,
+		},
+
+		"GetStationGroupsResponse": {
+			&GetStationGroupsResponse{
+				StationGroups: []GetStationGroupsResponse_StationGroup{
+					{
+						OrganizationID: "organization id",
+						Stations: []GetStationGroupsResponse_StationGroup_Station{
+							{StationID: "station id"},
+						},
+					},
+				},
+			},
+			`<getStationGroupsResponse xmlns="urn:dictionary:com.chargepoint.webservices">
+			  <responseCode></responseCode>
+			  <groupData>
+			    <orgID>organization id</orgID>
+			    <stationData>
+			      <stationID>station id</stationID>
+			    </stationData>
+			  </groupData>
+			</getStationGroupsResponse>`,
+		},
+
+		"GetStationsRequest": {
+			&GetStationsRequest{
+				StationID: "station id",
+				PricingSession: &GetStationsRequest_PricingSession{
+					StartTime: "some time",
+				},
+				DemoStationSerialNumbers: []string{"serial number"},
+			},
+			`<getStations xmlns="urn:dictionary:com.chargepoint.webservices">
+			  <searchQuery>
+			    <stationID>station id</stationID>
+			    <Pricing>
+			      <startTime>some time</startTime>
+			      <Duration>0</Duration>
+			      <energyRequired>0</energyRequired>
+			      <vehiclePower>0</vehiclePower>
+			    </Pricing>
+			    <demoSerialNumber>
+			      <serialNumber>serial number</serialNumber>
+			    </demoSerialNumber>
+			  </searchQuery>
+			</getStations>`,
+		},
+
+		"GetStationsResponse": {
+			&GetStationsResponse{
+				Stations: []GetStationsResponse_Station{
+					{
+						StationID: "station id",
+						Ports: []GetStationsResponse_Station_Port{
+							{PortNumber: "port number"},
+						},
+						PricingSpecification: []GetStationsResponse_Station_PricingSpecification{
+							{Type: "Session"},
+						},
+					},
+				},
+			},
+			`<getStationsResponse xmlns="urn:dictionary:com.chargepoint.webservices">
+			  <responseCode></responseCode>
+			  <stationData>
+			    <stationID>station id</stationID>
+			    <orgID></orgID>
+			    <organizationName></organizationName>
+			    <Port>
+			      <portNumber>port number</portNumber>
+			    </Port>
+			    <Pricing>
+			      <Type>Session</Type>
+			    </Pricing>
+			  </stationData>
+			</getStationsResponse>`,
+		},
+
+		"ShedLoadRequest_StationGroupID": {
+			&ShedLoadRequest{
+				StationGroupID:            1234,
+				StationGroupAllowedLoadKW: "0.5",
+			},
+			`<shedLoad xmlns="urn:dictionary:com.chargepoint.webservices">
+			  <shedQuery>
+			    <shedGroup>
+			      <sgID>1234</sgID>
+			      <allowedLoadPerStation>0.5</allowedLoadPerStation>
+			    </shedGroup>
+			    <shedStation>
+			      <stationID></stationID>
+			      <Ports></Ports>
+			    </shedStation>
+			    <timeInterval>0</timeInterval>
+			  </shedQuery>
+			</shedLoad>`,
+		},
+		"ShedLoadRequest_StationID": {
+			&ShedLoadRequest{
+				StationID:            "station id",
+				StationAllowedLoadKW: "0.5",
+			},
+			`<shedLoad xmlns="urn:dictionary:com.chargepoint.webservices">
+			  <shedQuery>
+			    <shedGroup></shedGroup>
+			    <shedStation>
+			      <stationID>station id</stationID>
+			      <allowedLoadPerStation>0.5</allowedLoadPerStation>
+			      <Ports></Ports>
+			    </shedStation>
+			    <timeInterval>0</timeInterval>
+			  </shedQuery>
+			</shedLoad>`,
+		},
+		"ShedLoadRequest_Ports": {
+			&ShedLoadRequest{
+				StationID: "station id",
+				Ports: []ShedLoadRequest_Port{
+					{PortNumber: "port number", AllowedLoadKW: "0.5"},
+				},
+			},
+			`<shedLoad xmlns="urn:dictionary:com.chargepoint.webservices">
+			  <shedQuery>
+			    <shedGroup></shedGroup>
+			    <shedStation>
+			      <stationID>station id</stationID>
+			      <Ports>
+			        <Port>
+			          <portNumber>port number</portNumber>
+			          <allowedLoadPerPort>0.5</allowedLoadPerPort>
+			        </Port>
+			      </Ports>
+			    </shedStation>
+			    <timeInterval>0</timeInterval>
+			  </shedQuery>
+			</shedLoad>`,
+		},
+
+		"ShedLoadResponse": {
+			&ShedLoadResponse{
+				Success:        1,
+				StationGroupID: 1234,
+				Ports: []ShedLoadResponse_Port{
+					{PortNumber: "port number", AllowedLoadKW: "0.5"},
+				},
+			},
+			`<shedLoadResponse xmlns="urn:dictionary:com.chargepoint.webservices">
+			  <responseCode></responseCode>
+			  <Success>1</Success>
+			  <sgID>1234</sgID>
+			  <Ports>
+			    <Port>
+			      <portNumber>port number</portNumber>
+			      <allowedLoadPerPort>0.5</allowedLoadPerPort>
+			    </Port>
+			  </Ports>
+			</shedLoadResponse>`,
+		},
+	} {
+		expected := envelopeRE.ReplaceAllString(tt.Expected, "<")
+
+		if b, err := xml.Marshal(tt.Value); err != nil {
+			t.Errorf("%s: xml.Marshal() = %q; want nil", name, err)
+		} else if diff := cmp.Diff(expected, string(b)); diff != "" {
+			t.Errorf("%s: marshaling mismatch (-want +got):\n%s", name, diff)
+		}
+	}
+}


### PR DESCRIPTION
This is a reasonable first attempt that creates a minimum of additional types.  This approach (using implicit element nesting via `xml:"parent>child"`) results in a large number of empty elements, which may cause problems with the real API, and may need to be reconsidered in the future.

* Adds marshaling tests for all top-level (i.e., request and response) messages.
* Remove the use of `big.Rat` as a field type, as it marshals like `1/2`, instead of `0.5`