### PR TITLE
Chargepoint API server: Add text/xml header

### DIFF
--- a/controller/chargepoint/api/server.go
+++ b/controller/chargepoint/api/server.go
@@ -82,6 +82,7 @@ func NewHandler(server ChargePointServer) http.Handler {
 			http.Error(w, "Failed marshaling the reply", http.StatusInternalServerError)
 			return
 		} else {
+			w.Header().Add("Content-Type", "text/xml;charset=UTF-8")
 			w.Write(rBytes)
 		}
 	})


### PR DESCRIPTION
Chargepoint API replies are in xml format. By default net/http library uses "text/plain; charset=utf-8" content type, which can confuse the API users. The content type of API reply packets should be "text/xml; charset=utf-8".
