### PR TITLE
EV charger simulator

### DIFF
--- a/controller/chargepoint/simulator/README.md
+++ b/controller/chargepoint/simulator/README.md
@@ -1,0 +1,20 @@
+# EV chargers simulator
+
+This simulator emulates ChargePoint web API for accessing EV chargers.
+At the current stage it works only in "replay" mode:
+ - Load historical data from excel or json files
+ - Reply these data via the ChargePoint APIs:
+  - `GetCPNInstances`
+  - `GetStationGroups`
+  - `GetStations`
+  - `GetLoad`
+ 	
+## Running the simulator:
+1. Read the data from excel file and serve them:
+   ```bash
+   go run main.go --file <excel file with recorded charging data>
+   ```
+2. Read the data from json files and serve them:
+   ```bash
+   go run main.go --dir <directory with json files with recorded charging data>
+   ```

--- a/controller/chargepoint/simulator/main.go
+++ b/controller/chargepoint/simulator/main.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020 VMware, Inc. Tzvetomir Stoyanov (VMware) <tz.stoyanov@gmail.com>
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/CamusEnergy/kinney/controller/chargepoint/api"
+	"github.com/CamusEnergy/kinney/controller/chargepoint/simulator/sim"
+)
+
+var (
+	file = flag.String("file", "", "excel file with recorded EV chargers data")
+	dir  = flag.String("dir", "", "directory with json files, with recorded EV chargers data")
+	addr = flag.String("addr", ":8080", "IP address and port in format IP:port, used for listening for incoming API requests.")
+	url  = flag.String("url", "/", "API endpoint")
+)
+
+func main() {
+	flag.Parse()
+	ev := sim.NewEvChargers()
+	var count int
+
+	if *file != "" {
+		c, err := sim.DataLoadExFile(file, ev)
+		if err != nil {
+			log.Fatal(err)
+		}
+		count += c
+	}
+
+	if *dir != "" {
+		c, err := sim.DataLoadJsonDir(dir, ev)
+		if err != nil {
+			log.Fatal(err)
+		}
+		count += c
+	}
+
+	fmt.Print("Loaded ", count, " samples")
+	fmt.Println()
+	sim.DataPrint(ev)
+
+	mux := http.NewServeMux()
+	mux.Handle(*url, api.NewHandler(sim.SimulatorServer{Ev: ev}))
+	err := http.ListenAndServe(*addr, mux)
+
+	fmt.Println(err)
+}

--- a/controller/chargepoint/simulator/sim/data.go
+++ b/controller/chargepoint/simulator/sim/data.go
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020 VMware, Inc. Tzvetomir Stoyanov (VMware) <tz.stoyanov@gmail.com>
+
+package sim
+
+import (
+	"flag"
+	"fmt"
+	"sync"
+	"time"
+)
+
+type locGeo struct {
+	lat  string
+	long string
+}
+
+type chargeSample struct {
+	time  time.Time
+	power float32
+}
+
+type vehicle struct {
+	driverId     *string
+	credentialID *string
+}
+
+type chargeSession struct {
+	vehicle vehicle
+	samples []*chargeSample
+}
+
+type chargePort struct {
+	sched    int
+	recorded []*chargeSession
+}
+
+type chargeStation struct {
+	geo     *locGeo
+	name    *string
+	address *string
+	ports   map[string]*chargePort
+}
+
+type chargeGetLoad interface {
+	calcTime(group *chargeGroup) time.Time
+	getPortLoad(port *chargePort, t time.Time) (float32, *vehicle, error)
+	printGetLoadParams()
+}
+
+type chargeGroup struct {
+	name     *string
+	stations map[string]*chargeStation
+	getLoad  chargeGetLoad
+}
+
+type chargeFacility struct {
+	name   *string
+	groups map[string]*chargeGroup
+}
+
+type chargeNetwork struct {
+	name *string
+	desc *string
+}
+
+type EVChargers struct {
+	lock       sync.Mutex
+	drivers    map[string]int
+	facilities map[string]*chargeFacility
+	networks   map[string]*chargeNetwork
+}
+
+const (
+	vmwareOrganizationID   = "1:19400001"
+	vmwareOrganizationName = "VMware"
+
+	geoDefLat  = "42.63228390329662"
+	geoDefLong = "23.378210952553545"
+
+	cpnDefName = "Virtual"
+	cpnDefDesc = "EV charger simulator"
+
+	threshold = 60 * time.Minute
+)
+
+var (
+	printSummary = flag.Bool("print_summary", false, "Print summary of sessions for debugging.")
+	printDetail  = flag.Bool("print_detail", false, "Print session details for debugging.")
+)
+
+// addChargeProbe adds new recorded charge probe
+func (e *EVChargers) addChargeProbe(faciltyID, groupID, stationID, portID, driver, credential *string, t time.Time, power float32) {
+	var s *chargeSession
+	sample := chargeSample{time: t, power: power}
+
+	port := e.getChargePort(faciltyID, groupID, stationID, portID)
+	if len(port.recorded) > 0 {
+		lastCharge := port.recorded[len(port.recorded)-1]
+		if *lastCharge.vehicle.driverId == *driver && len(lastCharge.samples) > 0 {
+			lastSample := lastCharge.samples[len(lastCharge.samples)-1]
+			diff := t.Sub(lastSample.time)
+			if diff < threshold {
+				s = lastCharge
+			}
+		}
+	}
+
+	if s != nil {
+		s.samples = append(s.samples, &sample)
+	} else {
+		s = &chargeSession{
+			vehicle: vehicle{
+				driverId:     driver,
+				credentialID: credential,
+			},
+			samples: make([]*chargeSample, 0),
+		}
+		s.samples = append(s.samples, &sample)
+		port.recorded = append(port.recorded, s)
+		e.drivers[*driver]++
+	}
+}
+
+func (e *EVChargers) getChargePort(faciltyID, groupID, stationID, id *string) *chargePort {
+	s := e.getChargeStation(faciltyID, groupID, stationID, nil, nil, nil)
+	if _, ok := s.ports[*id]; ok {
+		return s.ports[*id]
+	}
+
+	s.ports[*id] = &chargePort{recorded: make([]*chargeSession, 0)}
+	return s.ports[*id]
+}
+
+func (e *EVChargers) getChargeStation(faciltyID, groupID, id, name, address *string, loc *locGeo) *chargeStation {
+	g := e.getChargeGroup(faciltyID, groupID, nil, nil)
+	if _, ok := g.stations[*id]; ok {
+		return g.stations[*id]
+	}
+
+	g.stations[*id] = &chargeStation{
+		geo:     loc,
+		name:    name,
+		address: address,
+		ports:   make(map[string]*chargePort),
+	}
+	return g.stations[*id]
+}
+
+func (e *EVChargers) getChargeGroup(faciltyID, id, name *string, gload chargeGetLoad) *chargeGroup {
+	f := e.getChargeFacility(faciltyID, nil)
+	if _, ok := f.groups[*id]; ok {
+		return f.groups[*id]
+	}
+
+	f.groups[*id] = &chargeGroup{
+		name:     name,
+		stations: make(map[string]*chargeStation),
+		getLoad:  gload,
+	}
+	return f.groups[*id]
+}
+
+func (e *EVChargers) getChargeFacility(id, name *string) *chargeFacility {
+	if _, ok := e.facilities[*id]; ok {
+		return e.facilities[*id]
+	}
+
+	e.facilities[*id] = &chargeFacility{
+		name:   name,
+		groups: make(map[string]*chargeGroup),
+	}
+	return e.facilities[*id]
+}
+
+func (e *EVChargers) getCPNetwork(id, name, descriprtion *string) *chargeNetwork {
+	if _, ok := e.networks[*id]; ok {
+		return e.networks[*id]
+	}
+
+	e.networks[*id] = &chargeNetwork{
+		name: name,
+		desc: descriprtion,
+	}
+	return e.networks[*id]
+}
+
+func NewEvChargers() *EVChargers {
+	return &EVChargers{
+		drivers:    make(map[string]int),
+		facilities: make(map[string]*chargeFacility),
+		networks:   make(map[string]*chargeNetwork),
+	}
+}
+
+// DataPrint prints the entire database with all charger ports
+func DataPrint(e *EVChargers) {
+	fmt.Println("Vechicles:", len(e.drivers))
+	for i, v := range e.drivers {
+		fmt.Println("\t", i, "charged ", v, "times")
+
+	}
+	fmt.Println()
+
+	for o, org := range e.facilities {
+		fmt.Println("Organization", *org.name, o)
+		for i, gr := range org.groups {
+			fmt.Printf("\tStation group %s [%s]\n", i, *gr.name)
+
+			gr.getLoad.printGetLoadParams()
+			for j, st := range gr.stations {
+				fmt.Printf("\t\tStation %s [%s]\n", j, *st.name)
+				for k, pr := range st.ports {
+					fmt.Println("\t\t\tPort", k, ", charges:", len(pr.recorded))
+					if !*printSummary && !*printDetail {
+						continue
+					}
+					for _, k := range pr.recorded {
+						chargeTime := k.samples[len(k.samples)-1].time.Sub(k.samples[0].time)
+						fmt.Println("\t Driver [", *k.vehicle.driverId, *k.vehicle.credentialID, "] probes",
+							len(k.samples), "Total time:", chargeTime)
+						if !*printDetail {
+							continue
+						}
+						for _, s := range k.samples {
+							fmt.Println("\t\t", s.time, s.power)
+						}
+					}
+				}
+				fmt.Println()
+			}
+		}
+		fmt.Println()
+	}
+}

--- a/controller/chargepoint/simulator/sim/data_getload.go
+++ b/controller/chargepoint/simulator/sim/data_getload.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020 VMware, Inc. Tzvetomir Stoyanov (VMware) <tz.stoyanov@gmail.com>
+
+package sim
+
+import (
+	"fmt"
+
+	"github.com/CamusEnergy/kinney/controller/chargepoint/api/schema"
+)
+
+func getStationLoad(group *chargeGroup, st *chargeStation, stId *string, res *schema.GetLoadResponse) (float32, error) {
+	var sload float32
+	sret := schema.GetLoadResponse_Station{StationID: *stId}
+	if st.name != nil {
+		sret.StationName = *st.name
+	}
+	if st.address != nil {
+		sret.StationAddress = *st.address
+	}
+
+	simTime := group.getLoad.calcTime(group)
+	for i, port := range st.ports {
+		if p, v, err := group.getLoad.getPortLoad(port, simTime); err == nil {
+			sload += p
+			rport := schema.GetLoadResponse_Station_Port{
+				PortNumber: i,
+			}
+			rport.PortLoadKW = fmt.Sprintf("%f", p)
+			if v != nil {
+				rport.UserID = *v.driverId
+				rport.CredentialID = v.credentialID
+			}
+			sret.Ports = append(sret.Ports, rport)
+		}
+	}
+	sret.StationLoadKW = fmt.Sprintf("%f", sload)
+	res.Stations = append(res.Stations, sret)
+	return sload, nil
+}
+
+func (e *EVChargers) getNextLoad(resp *schema.GetLoadResponse,
+	group *chargeGroup, stationID *string) error {
+	var gload float32
+
+	if group == nil || stationID == nil {
+		return fmt.Errorf("Station not found")
+	}
+
+	e.lock.Lock()
+	defer e.lock.Unlock()
+
+	if *stationID == "" {
+		for i, s := range group.stations {
+			if p, err := getStationLoad(group, s, &i, resp); err == nil {
+				gload += p
+			}
+		}
+	} else {
+		if s, ok := group.stations[*stationID]; ok {
+			if p, err := getStationLoad(group, s, stationID, resp); err == nil {
+				gload += p
+			}
+		} else {
+			return fmt.Errorf("Station not found")
+		}
+	}
+
+	resp.StationGroupLoadKW = fmt.Sprintf("%f", gload)
+
+	return nil
+}

--- a/controller/chargepoint/simulator/sim/data_load_excel.go
+++ b/controller/chargepoint/simulator/sim/data_load_excel.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020 VMware, Inc. Tzvetomir Stoyanov (VMware) <tz.stoyanov@gmail.com>
+
+package sim
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	ex "github.com/360EntSecGroup-Skylar/excelize/v2"
+)
+
+func DataLoadExFile(file *string, e *EVChargers) (int, error) {
+	var samples int
+	credential := ""
+
+	f, err := ex.OpenFile(*file)
+	if err != nil {
+		return samples, err
+	}
+
+	cpnID := "1"
+	cpnName := cpnDefName
+	cpnDesc := cpnDefDesc
+	e.getCPNetwork(&cpnID, &cpnName, &cpnDesc)
+
+	vmGroup := vmwareOrganizationID
+	vmName := vmwareOrganizationName
+	e.getChargeFacility(&vmGroup, &vmName)
+
+	sheets := f.GetSheetMap()
+	for _, name := range sheets {
+		rows, err := f.GetRows(name)
+		if err != nil {
+			fmt.Println(err)
+			continue
+		}
+
+		for _, col := range rows[1:] {
+			var i int
+
+			if len(col) < 4 || len(col) > 6 {
+				continue
+			}
+			/*
+				col[0]: Timestamp,		"1583550049.76136"
+				col[1]: VehicleID,		"HNA3BC734CE51"
+				col[2]: Charge,			"5.661"
+				col[3]: Full-Port-ID	"238421*1:569591*2"
+			*/
+			for i = 0; i < 4; i++ {
+				if col[i] == "" {
+					break
+				}
+			}
+			if i < 4 {
+				continue
+			}
+			vehicle := strings.TrimSpace(col[1])
+			port := strings.TrimSpace(col[3])
+
+			times := strings.SplitN(col[0], ".", -1)
+			t1, err := strconv.ParseInt(times[0], 10, 64)
+			if err != nil {
+				continue
+			}
+			t2, err := strconv.ParseInt(times[1], 10, 64)
+			if err != nil {
+				continue
+			}
+			p, err := strconv.ParseFloat(col[2], 32)
+			if err != nil {
+				continue
+			}
+
+			ids := strings.SplitN(port, "*", -1)
+			if ids[0] == "" || ids[1] == "" || ids[2] == "" {
+				continue
+			}
+			empty := ""
+			e.getChargeGroup(&vmGroup, &ids[0], &empty, &getLoadReplay{})
+			e.getChargeStation(&vmGroup, &ids[0], &ids[1], &empty, &empty,
+				&locGeo{lat: geoDefLat, long: geoDefLong})
+			e.addChargeProbe(&vmGroup, &ids[0], &ids[1], &ids[2], &vehicle, &credential, time.Unix(t1, t2), float32(p))
+
+			samples++
+		}
+	}
+
+	sortReplaySamples(e)
+
+	return samples, nil
+}

--- a/controller/chargepoint/simulator/sim/data_load_json.go
+++ b/controller/chargepoint/simulator/sim/data_load_json.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020 VMware, Inc. Tzvetomir Stoyanov (VMware) <tz.stoyanov@gmail.com>
+
+package sim
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"math"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type StationPort struct {
+	PortNumber   string  `json:"portNumber"`
+	UserID       string  `json:"userID"`
+	CredentialID string  `json:"credentialID"`
+	ShedState    int     `json:"shedState"`
+	PortLoad     float32 `json:"portLoad"`
+	AllowedLoad  float32 `json:"allowedLoad"`
+	PercentShed  int     `json:"percentShed"`
+}
+
+type StationData struct {
+	StationID   string        `json:"stationID"`
+	StationName string        `json:"stationName"`
+	Address     string        `json:"Address"`
+	StationLoad float32       `json:"stationLoad"`
+	Ports       []StationPort `json:"Port"`
+}
+
+type ChargeData struct {
+	ResponseCode string        `json:"responseCode"`
+	ResponseText string        `json:"responseText"`
+	SgID         int           `json:"sgID"`
+	NumStations  int           `json:"numStations"`
+	GroupName    string        `json:"groupName"`
+	SgLoad       string        `json:"sgLoad"`
+	Stations     []StationData `json:"stationData"`
+}
+
+type ChargeRecord struct {
+	Ts   float64    `json:"ts"`
+	Data ChargeData `json:"data"`
+}
+
+type records struct {
+	Records []ChargeRecord `json:"records"`
+}
+
+func json2ev(jrec *records, e *EVChargers) int {
+	var samples int
+
+	cpnID := "1"
+	cpnName := cpnDefName
+	cpnDesc := cpnDefDesc
+	e.getCPNetwork(&cpnID, &cpnName, &cpnDesc)
+
+	vmGroup := vmwareOrganizationID
+	vmName := vmwareOrganizationName
+	e.getChargeFacility(&vmGroup, &vmName)
+
+	for _, r := range jrec.Records {
+		if r.Data.ResponseCode != "100" {
+			continue
+		}
+		sgid := strconv.Itoa(r.Data.SgID)
+		e.getChargeGroup(&vmGroup, &sgid, &r.Data.GroupName, &getLoadReplay{})
+
+		for _, s := range r.Data.Stations {
+			e.getChargeStation(&vmGroup, &sgid, &s.StationID, &s.StationName,
+				&s.Address, &locGeo{lat: geoDefLat, long: geoDefLong})
+			for _, p := range s.Ports {
+				e.getChargePort(&vmGroup, &sgid, &s.StationID, &p.PortNumber)
+				if p.PortLoad != 0 && p.CredentialID != "" {
+					sec, dec := math.Modf(r.Ts)
+					time := time.Unix(int64(sec), int64(dec*(1e9)))
+					e.addChargeProbe(&vmGroup, &sgid, &s.StationID,
+						&p.PortNumber, &p.UserID, &p.CredentialID, time, p.PortLoad)
+					samples++
+				}
+			}
+		}
+	}
+
+	return samples
+}
+
+func jsonLoad(fname *string, e *EVChargers) (int, error) {
+	var recs records
+
+	if file, err := os.Open(*fname); err != nil {
+		return 0, err
+	} else {
+		defer file.Close()
+		if data, err := ioutil.ReadAll(file); err != nil {
+			return 0, err
+		} else if err := json.Unmarshal(data, &recs); err != nil {
+			return 0, err
+		}
+	}
+
+	return json2ev(&recs, e), nil
+}
+
+func DataLoadJsonDir(dir *string, e *EVChargers) (int, error) {
+	var samples int
+
+	err := filepath.Walk(*dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() || filepath.Ext(strings.TrimSpace(path)) != ".json" {
+			return nil
+		}
+
+		if numSamples, err := jsonLoad(&path, e); err == nil {
+			samples += numSamples
+		} else {
+			log.Println("Failed to load ", path, ":", err)
+		}
+
+		return nil
+	})
+
+	sortReplaySamples(e)
+
+	return samples, err
+}

--- a/controller/chargepoint/simulator/sim/data_replay.go
+++ b/controller/chargepoint/simulator/sim/data_replay.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020 VMware, Inc. Tzvetomir Stoyanov (VMware) <tz.stoyanov@gmail.com>
+
+package sim
+
+import (
+	"fmt"
+	"sort"
+	"time"
+)
+
+type getLoadReplay struct {
+	firstRecord time.Time
+	lastRecord  time.Time
+	timeOffset  time.Duration
+}
+
+// Match the current time to times of the recorded charge sessions
+func (g getLoadReplay) calcTime(group *chargeGroup) time.Time {
+	now := time.Now()
+	stime := now.Add(g.timeOffset)
+
+	if stime.Equal(g.firstRecord) || stime.Equal(g.lastRecord) ||
+		(stime.After(g.firstRecord) && stime.Before(g.lastRecord)) {
+		return stime
+	}
+	stime = g.firstRecord
+	g.timeOffset = g.firstRecord.Sub(now)
+
+	return stime
+}
+
+func (g getLoadReplay) getPortLoad(port *chargePort, t time.Time) (float32, *vehicle, error) {
+	var session *chargeSession
+	var pload float32
+
+	for _, s := range port.recorded {
+		if len(s.samples) < 1 {
+			continue
+		}
+		if t.Equal(s.samples[0].time) || t.Equal(s.samples[len(s.samples)-1].time) ||
+			(t.After(s.samples[0].time) && t.Before(s.samples[len(s.samples)-1].time)) {
+			session = s
+			break
+		}
+	}
+	if session != nil {
+		for i := len(session.samples) - 1; i >= 0; i-- {
+			if t.Equal(session.samples[i].time) {
+				pload = session.samples[i].power
+				break
+			} else if t.After(session.samples[i].time) {
+				if i == (len(session.samples) - 1) {
+					pload = session.samples[i].power
+					break
+				}
+				pload = (session.samples[i].power + session.samples[i+1].power) / 2
+				break
+			}
+		}
+		return pload, &session.vehicle, nil
+	}
+
+	return pload, nil, nil
+}
+
+func (g getLoadReplay) printGetLoadParams() {
+	fmt.Println("\t\tFirst record", g.firstRecord)
+	fmt.Println("\t\tLast record", g.lastRecord)
+}
+
+func sortSessionsSlice(sessions []*chargeSession) {
+	sort.SliceStable(sessions, func(i, j int) bool {
+		if len(sessions[i].samples) < 1 {
+			return true
+		}
+		if len(sessions[j].samples) < 1 {
+			return false
+		}
+
+		return sessions[i].samples[0].time.Before(sessions[j].samples[0].time)
+	})
+}
+
+func sortProbesSlice(probes []*chargeSample) {
+	sort.SliceStable(probes, func(i, j int) bool {
+		return probes[i].time.Before(probes[j].time)
+	})
+}
+
+// Sort recorded charge sessions according to their time
+// and save the times of first and last one, for each charger group
+func sortReplaySamples(e *EVChargers) {
+	for _, org := range e.facilities {
+		for _, gr := range org.groups {
+			if gr.getLoad == nil {
+				continue
+			}
+
+			replay, ok := gr.getLoad.(*getLoadReplay)
+			if !ok {
+				continue
+			}
+
+			for _, st := range gr.stations {
+				for _, pr := range st.ports {
+					for _, k := range pr.recorded {
+						sortProbesSlice(k.samples)
+					}
+					sortSessionsSlice(pr.recorded)
+					if len(pr.recorded) > 0 && len(pr.recorded[0].samples) > 0 {
+						f := pr.recorded[0].samples[0].time
+						a := pr.recorded[len(pr.recorded)-1]
+						l := a.samples[len(a.samples)-1].time
+						if replay.firstRecord.IsZero() {
+							replay.firstRecord = f
+							replay.lastRecord = l
+						} else {
+							if f.Before(replay.firstRecord) {
+								replay.firstRecord = f
+							}
+							if l.After(replay.lastRecord) {
+								replay.lastRecord = l
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/controller/chargepoint/simulator/sim/handlers.go
+++ b/controller/chargepoint/simulator/sim/handlers.go
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020 VMware, Inc. Tzvetomir Stoyanov (VMware) <tz.stoyanov@gmail.com>
+
+package sim
+
+import (
+	"strconv"
+
+	"github.com/CamusEnergy/kinney/controller/chargepoint/api/schema"
+)
+
+type SimulatorServer struct {
+	Ev *EVChargers
+}
+
+func (s SimulatorServer) GetLoad(req *schema.GetLoadRequest) (*schema.GetLoadResponse, error) {
+	resp := &schema.GetLoadResponse{}
+	var group *chargeGroup
+	var err error
+	sgid := ""
+
+	if req.StationGroupID != 0 {
+		sgid = strconv.Itoa(int(req.StationGroupID))
+	}
+
+	for _, f := range s.Ev.facilities {
+		if sgid != "" {
+			if g, ok := f.groups[sgid]; !ok {
+				continue
+			} else {
+				group = g
+			}
+		} else {
+			for i, g := range f.groups {
+				if id, err := strconv.Atoi(i); err == nil {
+					req.StationGroupID = int32(id)
+					group = g
+				}
+				break
+			}
+		}
+		break
+	}
+
+	err = s.Ev.getNextLoad(resp, group, &req.StationID)
+
+	resp.StationGroupNumStations = int32(len(group.stations))
+	resp.StationGroupID = req.StationGroupID
+	if group.name != nil {
+		resp.StationGroupName = *group.name
+	}
+
+	if err == nil {
+		resp.ResponseCode = "100"
+		resp.ResponseText = "OK"
+	} else {
+		resp.ResponseCode = "102"
+		resp.ResponseText = "No load recorded"
+	}
+
+	return resp, nil
+}
+
+func (s SimulatorServer) GetStations(req *schema.GetStationsRequest) (*schema.GetStationsResponse, error) {
+	resp := &schema.GetStationsResponse{}
+
+	for j, org := range s.Ev.facilities {
+		if req.OrganizationID != "" && req.OrganizationID != j {
+			continue
+		}
+		if req.OrganizationName != "" && req.OrganizationName != *org.name {
+			continue
+		}
+
+		for i, g := range org.groups {
+			if req.StationGroupID != "" && req.StationGroupID != i {
+				continue
+			}
+			if req.StationGroupName != "" && req.StationGroupName != *g.name {
+				continue
+			}
+
+			for k, st := range g.stations {
+				if req.StationID != "" && req.StationID != k {
+					continue
+				}
+
+				station := schema.GetStationsResponse_Station{
+					OrganizationID: j,
+					StationGroupID: i,
+					StationID:      k,
+					NumPorts:       int32(len(st.ports)),
+				}
+				if org.name != nil {
+					station.OrganizationName = *org.name
+				}
+				if st.address != nil {
+					station.Address = *st.address
+				}
+				for l := range st.ports {
+					port := schema.GetStationsResponse_Station_Port{
+						PortNumber: l,
+						Coordinate: &schema.Coordinate{
+							Latitude:  st.geo.lat,
+							Longitude: st.geo.long,
+						},
+					}
+					if st.name != nil {
+						port.StationName = *st.name
+					}
+					station.Ports = append(station.Ports, port)
+				}
+				resp.Stations = append(resp.Stations, station)
+			}
+		}
+	}
+
+	if len(resp.Stations) > 0 {
+		resp.ResponseCode = "100"
+		resp.ResponseText = "OK"
+
+	} else {
+		resp.ResponseCode = "102"
+		resp.ResponseText = "No stations found"
+	}
+
+	return resp, nil
+}
+
+func (s SimulatorServer) GetStationGroups(req *schema.GetStationGroupsRequest) (*schema.GetStationGroupsResponse, error) {
+	resp := &schema.GetStationGroupsResponse{}
+
+	for j, org := range s.Ev.facilities {
+		if req.OrganizationID != "" && req.OrganizationID != j {
+			continue
+		}
+		for i, g := range org.groups {
+			gid, err := strconv.ParseInt(i, 10, 32)
+			if err != nil {
+				continue
+			}
+			r := schema.GetStationGroupsResponse_StationGroup{
+				OrganizationID: j,
+				StationGroupID: int32(gid),
+			}
+			if org.name != nil {
+				r.OrganizationName = *org.name
+			}
+			if g.name != nil {
+				r.StationGroupName = *g.name
+			}
+			for k, st := range g.stations {
+				station := schema.GetStationGroupsResponse_StationGroup_Station{
+					StationID: k,
+					Coordinate: &schema.Coordinate{
+						Latitude:  st.geo.lat,
+						Longitude: st.geo.long,
+					},
+				}
+				r.Stations = append(r.Stations, station)
+			}
+			resp.StationGroups = append(resp.StationGroups, r)
+		}
+	}
+
+	if len(resp.StationGroups) > 0 {
+		resp.ResponseCode = "100"
+		resp.ResponseText = "OK"
+
+	} else {
+		resp.ResponseCode = "102"
+		resp.ResponseText = "No station groups found"
+	}
+
+	return resp, nil
+}
+
+func (s SimulatorServer) GetCPNInstances(req *schema.GetCPNInstancesRequest) (*schema.GetCPNInstancesResponse, error) {
+	resp := &schema.GetCPNInstancesResponse{}
+
+	for i, n := range s.Ev.networks {
+		nw := schema.GetCPNInstancesResponse_ChargePointNetwork{
+			ID: i,
+		}
+		if n.name != nil {
+			nw.Name = *n.name
+		}
+		if n.desc != nil {
+			nw.Description = *n.desc
+		}
+		resp.ChargePointNetworks = append(resp.ChargePointNetworks, nw)
+	}
+
+	return resp, nil
+}
+
+func (s SimulatorServer) ShedLoad(req *schema.ShedLoadRequest) (*schema.ShedLoadResponse, error) {
+	resp := &schema.ShedLoadResponse{}
+
+	resp.ResponseCode = "188"
+	resp.ResponseText = "Not implemented yet "
+
+	return resp, nil
+}
+
+func (s SimulatorServer) ClearShedState(req *schema.ClearShedStateRequest) (*schema.ClearShedStateResponse, error) {
+	resp := &schema.ClearShedStateResponse{}
+
+	resp.Success = false
+	if req.StationGroupID != nil {
+		resp.StationGroupID = *req.StationGroupID
+	}
+	if req.StationID != nil {
+		resp.StationID = *req.StationID
+	}
+	for _, org := range s.Ev.facilities {
+		for i, g := range org.groups {
+			id, err := strconv.ParseInt(i, 10, 32)
+			if err != nil {
+				continue
+			}
+			if req.StationGroupID != nil && *req.StationGroupID != int32(id) {
+				continue
+			}
+
+			for k, st := range g.stations {
+				if req.StationID != nil && *req.StationID != k {
+					continue
+				}
+				resp.Success = true
+				for _, pr := range st.ports {
+					pr.sched = 0
+				}
+			}
+		}
+	}
+	return resp, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,11 @@ module github.com/CamusEnergy/kinney
 go 1.13
 
 require (
+	github.com/360EntSecGroup-Skylar/excelize/v2 v2.2.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.4.0
 	github.com/google/go-cmp v0.4.0
 	github.com/grpc-ecosystem/grpc-gateway v1.14.3
-	golang.org/x/net v0.0.0-20200319234117-63522dbf7eec // indirect
-	golang.org/x/sys v0.0.0-20200317113312-5766fd39f98d // indirect
 	golang.org/x/text v0.3.2 // indirect
 	google.golang.org/genproto v0.0.0-20200319113533-08878b785e9c
 	google.golang.org/grpc v1.28.0


### PR DESCRIPTION
This simulator emulates ChargePoint web API for accessing EV chargers.  At the current stage it works only in "replay" mode:
- Load historical data from excel or json files
- Reply these data via the ChargePoint APIs:
  - `GetCPNInstances`
  - `GetStationGroups`
  - `GetStations`
  - `GetLoad`

Running the simulator:

1. Read the data from excel file and serve them:
   ```bash
   $ go run main.go --file <excel file with recorded charging data>
   ```

1. Read the data from json files and serve them:
   ```bash
   $ go run main.go --dir <directory with json files with recorded charging data>
   ```