### PR TITLE
ChargePoint simulator: Return the original error in GetLoad request

### DIFF
--- a/controller/chargepoint/simulator/sim/handlers.go
+++ b/controller/chargepoint/simulator/sim/handlers.go
@@ -45,7 +45,7 @@ func (s SimulatorServer) GetLoad(req *schema.GetLoadRequest) (*schema.GetLoadRes
 	err = s.Ev.getNextLoad(resp, group, &req.StationID)
 	if err != nil {
 		resp.ResponseCode = "102"
-		resp.ResponseText = "No load recorded"
+		resp.ResponseText = err.Error()
 	} else {
 		resp.ResponseCode = "100"
 		resp.ResponseText = "OK"


### PR DESCRIPTION
If there is an error in processing the GetLoad request, return the
original error string instead of rewriting it.

Signed-off-by: Tzvetomir Stoyanov (VMware) <tz.stoyanov@gmail.com>